### PR TITLE
Add Diversions game sessions for April 8, 2026

### DIFF
--- a/src/content/calendar/diversions-apr-08-2026.md
+++ b/src/content/calendar/diversions-apr-08-2026.md
@@ -1,0 +1,26 @@
+---
+title: Pathfinder Society at Diversions - April 8
+date: 2026-04-08
+url: /events/diversions-apr-08-2026
+location: Diversions
+address: 119 2nd St #300, Coralville, IA 52241
+---
+
+# Pathfinder Society at Diversions
+
+Join us for Pathfinder Society games at Diversions in Coralville!
+
+## Details
+
+- **Date:** April 8, 2026
+- **Location:** Diversions
+- **Address:** 119 2nd St #300, Coralville, IA 52241
+
+## Available Scenarios
+
+1. **Sewer Dragon Crisis** (Pathfinder Scenario, Levels 1-4) - **5:30 PM - 9:30 PM** - [Sign up here](https://www.rpgchronicles.net/session/074df87e-737d-4d38-9c25-1e4b6a92b71d/pregame)
+2. **Mountain of Sea and Sky** (Pathfinder Scenario, Levels 1-4) - **5:30 PM - 9:30 PM** - [Sign up here](https://www.rpgchronicles.net/session/db55995b-780e-4cc4-9a42-c24936fe9134/pregame)
+
+## Registration
+
+Please register in advance using the links above. Space is limited to 6 players per game, so sign up early!


### PR DESCRIPTION
## Summary

- Adds two Pathfinder Society scenarios at Diversions on April 8, 2026
- **Sewer Dragon Crisis** (Levels 1-4, 5:30–9:30 PM)
- **Mountain of Sea and Sky** (Levels 1-4, 5:30–9:30 PM)

## Test plan

- [x] Verify event appears on the calendar for April 8
- [x] Confirm both signup links are correct
- [x] Check event detail page renders at `/events/diversions-apr-08-2026`

🤖 Generated with [Claude Code](https://claude.com/claude-code)