### PR TITLE
Add Tempest Games Pathfinder sessions for April 16 and April 30, 2026

### DIFF
--- a/src/content/calendar/tempest-apr-16-2026.md
+++ b/src/content/calendar/tempest-apr-16-2026.md
@@ -1,0 +1,28 @@
+---
+title: Pathfinder Society at Tempest Games - Lions of Katapesh
+date: 2026-04-16
+url: /events/tempest-apr-16-2026
+location: Tempest Games
+address: 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+---
+
+# Pathfinder Society at Tempest Games
+
+Join us for Pathfinder Society games at Tempest Games in Cedar Rapids!
+
+## Details
+
+- **Date:** April 16, 2026
+- **Time:** 5:30 PM Central Time
+- **Location:** Tempest Games
+- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+- **Players:** 6 players
+- **Level Range:** 1-4
+
+## Available Scenarios
+
+1. **Lions of Katapesh** (Pathfinder Scenario, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/8e61c61b-59b1-4c9b-b95c-be910b4534ad/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 6 players, so sign up early!

--- a/src/content/calendar/tempest-apr-30-2026.md
+++ b/src/content/calendar/tempest-apr-30-2026.md
@@ -1,0 +1,29 @@
+---
+title: Pathfinder Society at Tempest Games - The Great Toy Heist
+date: 2026-04-30
+url: /events/tempest-apr-30-2026
+location: Tempest Games
+address: 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+---
+
+# Pathfinder Society at Tempest Games
+
+Join us for Pathfinder Society games at Tempest Games in Cedar Rapids!
+
+## Details
+
+- **Date:** April 30, 2026
+- **Time:** 5:30 PM Central Time
+- **Location:** Tempest Games
+- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+- **Players:** 4 players
+
+## Available Scenarios
+
+1. **The Great Toy Heist** (Pathfinder Scenario) - [Sign up here](https://www.rpgchronicles.net/session/a39e7feb-9a3d-4787-8a75-4083a24d70e8/pregame)
+
+> **Special Note:** This scenario uses pregenerated characters. The chronicle can be applied to any character you own, regardless of level.
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 4 players, so sign up early!


### PR DESCRIPTION
## Summary

- Adds **Lions of Katapesh** (Levels 1-4, 6 players) on April 16 at Tempest Games
- Adds **The Great Toy Heist** (pregen scenario, 4 players) on April 30 at Tempest Games — includes special note that the chronicle can be applied to any character regardless of level

## Test plan

- [x] Verify both events appear on the calendar in correct date order
- [x] Confirm signup links resolve correctly
- [x] Check pregen note renders properly on The Great Toy Heist event page

🤖 Generated with [Claude Code](https://claude.com/claude-code)