### PR TITLE
Add Replay Games Pathfinder session for April 28, 2026

### DIFF
--- a/src/content/calendar/replay-apr-28-2026.md
+++ b/src/content/calendar/replay-apr-28-2026.md
@@ -1,0 +1,26 @@
+---
+title: Pathfinder Society at Replay Games - The Chitterwood Walks, Part 1
+date: 2026-04-28
+url: /events/replay-apr-28-2026
+location: Replay Games
+address: 617 Center Point Rd NE, Cedar Rapids, IA 52402
+---
+
+# Pathfinder Society at Replay Games
+
+Join us for Pathfinder Society games at Replay Games in Cedar Rapids!
+
+## Details
+
+- **Date:** April 28, 2026
+- **Time:** 5:30 PM - 9:00 PM Central Time
+- **Location:** Replay Games
+- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402
+
+## Available Scenarios
+
+1. **The Chitterwood Walks, Part 1** (Pathfinder Scenario, Levels 3-4) - [Sign up here](https://www.rpgchronicles.net/session/4c819215-2c3c-43f7-8aed-d06287ce9244/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 5 players per game, so sign up early!


### PR DESCRIPTION
## Summary

- Adds calendar entry for Pathfinder Society at Replay Games on April 28, 2026 at 5:30 PM
- Scenario: The Chitterwood Walks, Part 1 (Levels 3-4, up to 5 players)
- Includes RPG Chronicles signup link

## Test plan

- [x] Verify event appears on calendar for April 28, 2026
- [x] Verify signup link navigates to correct RPG Chronicles page
- [x] Verify level range displays as 3-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)