### PR TITLE
Add Pathfinder sessions for May 2026 at GCG and Tempest

### DIFF
--- a/src/content/calendar/gcg-may-03-2026.md
+++ b/src/content/calendar/gcg-may-03-2026.md
@@ -1,0 +1,26 @@
+---
+title: Pathfinder Society at Geek City Games - Struck by Shadows
+date: 2026-05-03
+url: /events/gcg-may-03-2026
+location: Geek City Games
+address: 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+---
+
+# Pathfinder Society at Geek City Games
+
+Join us for Pathfinder Society games at Geek City Games in North Liberty!
+
+## Details
+
+- **Date:** May 3, 2026
+- **Time:** 12:00 noon - 4:00 PM Central Time
+- **Location:** Geek City Games
+- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+
+## Available Scenarios
+
+1. **Struck by Shadows** (Pathfinder Scenario, Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/274f9926-e147-4f7f-bc85-d280e694e5f9/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited, so sign up early!

--- a/src/content/calendar/tempest-may-07-2026.md
+++ b/src/content/calendar/tempest-may-07-2026.md
@@ -1,0 +1,28 @@
+---
+title: Pathfinder Society at Tempest Games - Perch of Liberty
+date: 2026-05-07
+url: /events/tempest-may-07-2026
+location: Tempest Games
+address: 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+---
+
+# Pathfinder Society at Tempest Games
+
+Join us for Pathfinder Society games at Tempest Games in Cedar Rapids!
+
+## Details
+
+- **Date:** May 7, 2026
+- **Time:** 5:30 PM Central Time
+- **Location:** Tempest Games
+- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+- **Players:** 5 players
+- **Level Range:** 3-4
+
+## Available Scenarios
+
+1. **Perch of Liberty** (Pathfinder Scenario, Levels 3-4) - [Sign up here](https://www.rpgchronicles.net/session/396e19f6-4704-43c9-a782-3b8b75532304/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 5 players, so sign up early!

--- a/src/content/calendar/tempest-may-21-2026.md
+++ b/src/content/calendar/tempest-may-21-2026.md
@@ -1,0 +1,27 @@
+---
+title: Pathfinder Society at Tempest Games - In the Footsteps of Horror
+date: 2026-05-21
+url: /events/tempest-may-21-2026
+location: Tempest Games
+address: 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+---
+
+# Pathfinder Society at Tempest Games
+
+Join us for Pathfinder Society games at Tempest Games in Cedar Rapids!
+
+## Details
+
+- **Date:** May 21, 2026
+- **Time:** 5:30 PM Central Time
+- **Location:** Tempest Games
+- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+- **Players:** 6 players
+
+## Available Scenarios
+
+1. **In the Footsteps of Horror** (Pathfinder Quest) - [Sign up here](https://www.rpgchronicles.net/session/40bcae81-4d6c-4c0b-8e86-25702baf291f/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 6 players, so sign up early!


### PR DESCRIPTION
## Summary

- GCG May 3: Struck by Shadows (Levels 3-6, noon)
- Tempest May 7: Perch of Liberty (Levels 3-4, 5:30 PM, 5 players)
- Tempest May 21: In the Footsteps of Horror (Quest, 5:30 PM, 6 players)

🤖 Generated with [Claude Code](https://claude.com/claude-code)