### PR TITLE
Add Geek City Games Pathfinder session for May 17, 2026

### DIFF
--- a/src/content/calendar/gcg-may-17-2026.md
+++ b/src/content/calendar/gcg-may-17-2026.md
@@ -1,0 +1,26 @@
+---
+title: Pathfinder Society at Geek City Games - The Locked Lodge
+date: 2026-05-17
+url: /events/gcg-may-17-2026
+location: Geek City Games
+address: 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+---
+
+# Pathfinder Society at Geek City Games
+
+Join us for Pathfinder Society games at Geek City Games in North Liberty!
+
+## Details
+
+- **Date:** May 17, 2026
+- **Time:** 12:00 noon - 4:00 PM Central Time
+- **Location:** Geek City Games
+- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+
+## Available Scenarios
+
+1. **The Locked Lodge** (Pathfinder Scenario, Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/bceae215-3def-4eb8-b9a8-54651abc47e9/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited, so sign up early!


### PR DESCRIPTION
## Summary
- Adds calendar entry for The Locked Lodge (Levels 3-6) at Geek City Games on May 17, 2026
- Noon–4:00 PM at 365 Beaver Kreek Center suite b, North Liberty, IA 52317
- Sign-up via RPG Chronicles

## Test plan
- [ ] Verify event appears on the calendar at the correct date
- [ ] Confirm sign-up link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)