### PR TITLE
Add Diversions Pathfinder & Starfinder sessions for May 13 and 27, 2026

### DIFF
--- a/src/content/calendar/diversions-may-13-2026.md
+++ b/src/content/calendar/diversions-may-13-2026.md
@@ -1,0 +1,27 @@
+---
+title: Pathfinder Society at Diversions - The Crocodile's Smile
+date: 2026-05-13
+url: /events/diversions-may-13-2026
+location: Diversions
+address: 119 2nd St #300, Coralville, IA 52241
+---
+
+# Pathfinder Society at Diversions
+
+Join us for Pathfinder Society games at Diversions in Coralville!
+
+## Details
+
+- **Date:** May 13, 2026
+- **Time:** 5:30 PM - 9:30 PM Central Time
+- **Location:** Diversions
+- **Address:** 119 2nd St #300, Coralville, IA 52241
+
+## Available Scenarios
+
+### Pathfinder Society
+1. **The Crocodile's Smile** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/7406a021-43f0-4d9a-9384-42bb6b8dad70/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited, so sign up early!

--- a/src/content/calendar/diversions-may-27-2026.md
+++ b/src/content/calendar/diversions-may-27-2026.md
@@ -20,7 +20,7 @@ Join us for Pathfinder and Starfinder Society games at Diversions in Coralville!
 ## Available Scenarios
 
 ### Pathfinder Society
-1. **Path of Kings** (Levels 3-5, starts 5:30 PM) - [Sign up here](https://www.rpgchronicles.net/session/430856d0-e7d0-4768-9535-75bab1319ac0/pregame)
+1. **Path of Kings** (Levels 3-6, starts 5:30 PM) - [Sign up here](https://www.rpgchronicles.net/session/430856d0-e7d0-4768-9535-75bab1319ac0/pregame)
 
 ### Starfinder Society
 1. **Friends of the Forest** (Levels 1-2, starts 6:00 PM, 5 players) - [Sign up here](https://www.rpgchronicles.net/session/6eca1c83-851f-4ff0-8538-5763a77cc3db/pregame)

--- a/src/content/calendar/diversions-may-27-2026.md
+++ b/src/content/calendar/diversions-may-27-2026.md
@@ -1,0 +1,30 @@
+---
+title: Pathfinder & Starfinder Society at Diversions - May 27
+date: 2026-05-27
+url: /events/diversions-may-27-2026
+location: Diversions
+address: 119 2nd St #300, Coralville, IA 52241
+---
+
+# Pathfinder & Starfinder Society at Diversions
+
+Join us for Pathfinder and Starfinder Society games at Diversions in Coralville!
+
+## Details
+
+- **Date:** May 27, 2026
+- **Time:** 5:30 PM - 9:30 PM Central Time
+- **Location:** Diversions
+- **Address:** 119 2nd St #300, Coralville, IA 52241
+
+## Available Scenarios
+
+### Pathfinder Society
+1. **Path of Kings** (Levels 3-5, starts 5:30 PM) - [Sign up here](https://www.rpgchronicles.net/session/430856d0-e7d0-4768-9535-75bab1319ac0/pregame)
+
+### Starfinder Society
+1. **Friends of the Forest** (Levels 1-2, starts 6:00 PM, 5 players) - [Sign up here](https://www.rpgchronicles.net/session/6eca1c83-851f-4ff0-8538-5763a77cc3db/pregame)
+
+## Registration
+
+Please register in advance using the links above. Space is limited, so sign up early!


### PR DESCRIPTION
## Summary

- Adds Pathfinder Society session on May 13 (The Crocodile's Smile, Levels 1-4)
- Adds Pathfinder Society session on May 27 (Path of Kings, Levels 3-5, 5:30 PM)
- Adds Starfinder Society session on May 27 (Friends of the Forest, Levels 1-2, 6:00 PM, 5 players)

## Test plan

- [ ] Verify all three scenarios appear on the calendar
- [ ] Confirm sign-up links resolve correctly
- [ ] Check May 27 event shows both Pathfinder and Starfinder sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)