### PR TITLE
Add Diversions Pathfinder session for May 13, 2026

### DIFF
--- a/src/content/calendar/diversions-may-13-2026.md
+++ b/src/content/calendar/diversions-may-13-2026.md
@@ -1,0 +1,26 @@
+---
+title: Pathfinder Society at Diversions - May 13
+date: 2026-05-13
+url: /events/diversions-may-13-2026
+location: Diversions
+address: 119 2nd St #300, Coralville, IA 52241
+---
+
+# Pathfinder Society at Diversions
+
+Join us for Pathfinder Society games at Diversions in Coralville!
+
+## Details
+
+- **Date:** May 13, 2026
+- **Time:** 6:00 PM
+- **Location:** Diversions
+- **Address:** 119 2nd St #300, Coralville, IA 52241
+
+## Available Scenarios
+
+1. **Perch of Liberty** (Pathfinder Scenario, Levels 3-4) - [Sign up here](https://www.rpgchronicles.net/session/2afeb9c2-b4b3-4d9c-badf-57df083645be/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 6 players per game, so sign up early!


### PR DESCRIPTION
## Summary

- Adds calendar entry for Pathfinder Society at Diversions on May 13, 2026 at 6:00 PM
- Scenario: **Perch of Liberty** (Levels 3-4)
- Signup link included

🤖 Generated with [Claude Code](https://claude.com/claude-code)