### PR TITLE
Add Replay Games Starfinder session for May 26, 2026

### DIFF
--- a/src/content/calendar/replay-may-26-2026.md
+++ b/src/content/calendar/replay-may-26-2026.md
@@ -1,0 +1,26 @@
+---
+title: Starfinder Society at Replay Games - The Great Absalom Relay
+date: 2026-05-26
+url: /events/replay-may-26-2026
+location: Replay Games
+address: 617 Center Point Rd NE, Cedar Rapids, IA 52402
+---
+
+# Starfinder Society at Replay Games
+
+Join us for Starfinder Society games at Replay Games in Cedar Rapids!
+
+## Details
+
+- **Date:** May 26, 2026
+- **Time:** 5:30 PM - 9:00 PM Central Time
+- **Location:** Replay Games
+- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402
+
+## Available Scenarios
+
+1. **The Great Absalom Relay** (Starfinder 2E Scenario) - [Sign up here](https://www.rpgchronicles.net/session/0966a386-c88a-46e6-bf70-c275169c493d/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 5 players, so sign up early!


### PR DESCRIPTION
Adds the Starfinder Society session at Replay Games on May 26, 2026.

- **Scenario:** The Great Absalom Relay (Starfinder 2E)
- **Date:** May 26, 2026, 5:30–9:00 PM
- **Location:** Replay Games, Cedar Rapids
- **Players:** 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)