### PR TITLE
Add Tempest Games and Geek City Games sessions for June 4 and 7, 2026

### DIFF
--- a/src/content/calendar/gcg-jun-07-2026.md
+++ b/src/content/calendar/gcg-jun-07-2026.md
@@ -1,0 +1,26 @@
+---
+title: Pathfinder Society at Geek City Games - Intro: Year of Boundless Wonder
+date: 2026-06-07
+url: /events/gcg-jun-07-2026
+location: Geek City Games
+address: 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+---
+
+# Pathfinder Society at Geek City Games
+
+Join us for Pathfinder Society games at Geek City Games in North Liberty!
+
+## Details
+
+- **Date:** June 7, 2026
+- **Time:** 12:00 noon - 4:00 PM Central Time
+- **Location:** Geek City Games
+- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+
+## Available Scenarios
+
+1. **Intro: Year of Boundless Wonder** (Pathfinder Quest) - [Sign up here](https://www.rpgchronicles.net/events/2a5ff593-a25f-41ae-85d8-9f48995d3b1f/dashboard)
+
+## Registration
+
+Please register in advance using the link above. Space is limited, so sign up early!

--- a/src/content/calendar/gcg-jun-07-2026.md
+++ b/src/content/calendar/gcg-jun-07-2026.md
@@ -1,5 +1,5 @@
 ---
-title: Pathfinder Society at Geek City Games - Intro: Year of Boundless Wonder
+title: "Pathfinder Society at Geek City Games - Intro: Year of Boundless Wonder"
 date: 2026-06-07
 url: /events/gcg-jun-07-2026
 location: Geek City Games

--- a/src/content/calendar/tempest-jun-04-2026.md
+++ b/src/content/calendar/tempest-jun-04-2026.md
@@ -1,0 +1,27 @@
+---
+title: Pathfinder Society at Tempest Games - The Dragon Who Stole Evoking Day
+date: 2026-06-04
+url: /events/tempest-jun-04-2026
+location: Tempest Games
+address: 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+---
+
+# Pathfinder Society at Tempest Games
+
+Join us for Pathfinder Society games at Tempest Games in Cedar Rapids!
+
+## Details
+
+- **Date:** June 4, 2026
+- **Time:** 5:30 PM Central Time
+- **Location:** Tempest Games
+- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+- **Players:** 5 players
+
+## Available Scenarios
+
+1. **The Dragon Who Stole Evoking Day** (Pathfinder Quest) - [Sign up here](https://www.rpgchronicles.net/session/bea133d4-29bf-46dc-9008-bad825b4ea19/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 5 players, so sign up early!


### PR DESCRIPTION
Adds two new calendar events:

- **Tempest Games, Jun 4**: PF Quest *The Dragon Who Stole Evoking Day*, 5:30 PM, 5 players
- **Geek City Games, Jun 7**: PF Quest *Intro: Year of Boundless Wonder*, noon

🤖 Generated with [Claude Code](https://claude.com/claude-code)