### PR TITLE
Update GCG Jun 7 signup URL and game type

### DIFF
--- a/src/content/calendar/gcg-jun-07-2026.md
+++ b/src/content/calendar/gcg-jun-07-2026.md
@@ -19,7 +19,7 @@ Join us for Pathfinder Society games at Geek City Games in North Liberty!
 
 ## Available Scenarios
 
-1. **Intro: Year of Boundless Wonder** (Pathfinder Quest) - [Sign up here](https://www.rpgchronicles.net/session/c5df7e83-d63f-46dc-8ce7-5a432d5d29e2/pregame)
+1. **Intro: Year of Boundless Wonder** (Pathfinder Scenario) - [Sign up here](https://www.rpgchronicles.net/session/c5df7e83-d63f-46dc-8ce7-5a432d5d29e2/pregame)
 
 ## Registration
 

--- a/src/content/calendar/gcg-jun-07-2026.md
+++ b/src/content/calendar/gcg-jun-07-2026.md
@@ -19,7 +19,7 @@ Join us for Pathfinder Society games at Geek City Games in North Liberty!
 
 ## Available Scenarios
 
-1. **Intro: Year of Boundless Wonder** (Pathfinder Quest) - [Sign up here](https://www.rpgchronicles.net/events/2a5ff593-a25f-41ae-85d8-9f48995d3b1f/dashboard)
+1. **Intro: Year of Boundless Wonder** (Pathfinder Quest) - [Sign up here](https://www.rpgchronicles.net/session/c5df7e83-d63f-46dc-8ce7-5a432d5d29e2/pregame)
 
 ## Registration
 


### PR DESCRIPTION
Updates the June 7 Geek City Games session for *Intro: Year of Boundless Wonder*:

- Fix signup URL to use pregame session link
- Correct game type from Pathfinder Quest → Pathfinder Scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)