### PR TITLE
Update checkout and configure-aws-credentials to Node 24 versions

### DIFF
--- a/.github/workflows/deploy-dev-on-pr.yml
+++ b/.github/workflows/deploy-dev-on-pr.yml
@@ -21,7 +21,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -33,7 +33,7 @@ jobs:
         run: npm ci
         
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
           role-session-name: GitHubActions-DevDeploy

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -31,7 +31,7 @@ jobs:
         run: npm ci
         
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: GitHubActions-ProductionDeploy


### PR DESCRIPTION
Resolves remaining Node.js 20 deprecation warnings on GitHub Actions runners.

## Changes

- `actions/checkout`: `@v4` → `@v6` (v6.0.2, Node 24 runtime)
- `aws-actions/configure-aws-credentials`: `@v4` → `@v6` (v6.1.1, Node 24 runtime)

All actions in both workflows now run on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)