### PR TITLE
Promote Steve S from Venture Agent to Venture Lieutenant

### DIFF
--- a/src/content/gamemasters/steve-s.md
+++ b/src/content/gamemasters/steve-s.md
@@ -5,7 +5,7 @@ firstName: Steve
 lastInitial: S
 organizedPlayNumber: 21564
 games: [Pathfinder]
-ventureOfficer: Venture Agent
+ventureOfficer: Venture Lieutenant
 ---
 
 Steve is a dedicated Game Master who runs Pathfinder Society scenarios. With organized play number 21564, Steve brings enthusiasm and expertise to create engaging adventures for players of all experience levels.

--- a/src/data/gamemasters.json
+++ b/src/data/gamemasters.json
@@ -95,7 +95,7 @@
       "games": [
         "Pathfinder"
       ],
-      "ventureOfficer": "Venture Agent"
+      "ventureOfficer": "Venture Lieutenant"
     },
     "content": "\nSteve is a dedicated Game Master who runs Pathfinder Society scenarios. With organized play number 21564, Steve brings enthusiasm and expertise to create engaging adventures for players of all experience levels.",
     "slug": "steve-s",


### PR DESCRIPTION
## Summary

- Updates Steve S's venture officer title from Venture Agent to Venture Lieutenant in his GM profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)