### PR TITLE
Add lodge party news article for June 8, 2026

### DIFF
--- a/src/content/news/lodge-party-jun-2026.md
+++ b/src/content/news/lodge-party-jun-2026.md
@@ -1,0 +1,31 @@
+---
+title: Lodge Party - June 8th!
+date: 2026-05-31
+id: lodge-party-jun-2026
+---
+
+# Lodge Party - June 8th!
+
+You've rolled a natural 20 on your social check — you're invited to the Shifting Corridors Lodge Party!
+
+## You're Invited
+
+On **June 8th from 5:30 PM to 9:30 PM**, we're throwing a party for the people who make this lodge great: our players, GMs, Venture Officers, and Store Hosts. Families are welcome too — the more the merrier!
+
+Drop in when you can, leave when you need to. No pressure, no agenda, just good company.
+
+## What to Expect
+
+- Party games — both indoor and outdoor
+- Food served throughout the evening
+- Great company from across the lodge
+
+## Getting an Invite
+
+The location is shared with the invite (we're keeping the address off the public internet). To get yours, reach out through any of these:
+
+- **Email:** [lodge@shiftingcorridors.com](mailto:lodge@shiftingcorridors.com)
+- **Discord:** Ask in the server
+- **In person:** Find Marty H or Sam H
+
+We hope to see you there!

--- a/src/data/news.json
+++ b/src/data/news.json
@@ -1,6 +1,16 @@
 [
   {
     "meta": {
+      "title": "Lodge Party - June 8th!",
+      "date": "2026-05-31T00:00:00.000Z",
+      "id": "lodge-party-jun-2026"
+    },
+    "content": "\n# Lodge Party - June 8th!\n\nYou've rolled a natural 20 on your social check — you're invited to the Shifting Corridors Lodge Party!\n\n## You're Invited\n\nOn **June 8th from 5:30 PM to 9:30 PM**, we're throwing a party for the people who make this lodge great: our players, GMs, Venture Officers, and Store Hosts. Families are welcome too — the more the merrier!\n\nDrop in when you can, leave when you need to. No pressure, no agenda, just good company.\n\n## What to Expect\n\n- Party games — both indoor and outdoor\n- Food served throughout the evening\n- Great company from across the lodge\n\n## Getting an Invite\n\nThe location is shared with the invite (we're keeping the address off the public internet). To get yours, reach out through any of these:\n\n- **Email:** [lodge@shiftingcorridors.com](mailto:lodge@shiftingcorridors.com)\n- **Discord:** Ask in the server\n- **In person:** Find Marty H or Sam H\n\nWe hope to see you there!\n",
+    "slug": "lodge-party-jun-2026",
+    "directory": "news"
+  },
+  {
+    "meta": {
       "title": "No Show and Timeliness Policy",
       "date": "2025-12-05T00:00:00.000Z",
       "id": "no-show-timeliness-policy"


### PR DESCRIPTION
## Summary

- Adds news article announcing the June 8 lodge party
- Covers time, format, what to expect, and how to get an invite (location kept off the public site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)