### PR TITLE
Add Lodge Party calendar event for June 8, 2026

### DIFF
--- a/src/content/calendar/lodge-party-jun-08-2026.md
+++ b/src/content/calendar/lodge-party-jun-08-2026.md
@@ -1,0 +1,33 @@
+---
+title: Shifting Corridors Lodge Party
+date: 2026-06-08
+url: /events/lodge-party-jun-08-2026
+---
+
+# Shifting Corridors Lodge Party
+
+Come celebrate with your fellow adventurers at the Shifting Corridors Lodge Party!
+
+## Details
+
+- **Date:** June 8, 2026
+- **Time:** 5:30 PM - 9:30 PM Central Time
+- **Drop in and out as you please!**
+
+## Who's Invited
+
+All players, GMs, Venture Officers, and Store Hosts — and their families! If you're part of this community, you're welcome.
+
+## What to Expect
+
+Party games (indoor and outdoor), food, and great company from across the lodge.
+
+## Getting an Invite
+
+The location is shared privately with your invite. Reach out through any of these:
+
+- **Email:** [lodge@shiftingcorridors.com](mailto:lodge@shiftingcorridors.com)
+- **Discord:** Ask in the server
+- **In person:** Find Marty H or Sam H
+
+No signup required — just get your invite and show up!

--- a/src/data/calendar.json
+++ b/src/data/calendar.json
@@ -25,6 +25,16 @@
   },
   {
     "meta": {
+      "title": "Shifting Corridors Lodge Party",
+      "date": "2026-06-08T00:00:00.000Z",
+      "url": "/events/lodge-party-jun-08-2026"
+    },
+    "content": "\n# Shifting Corridors Lodge Party\n\nCome celebrate with your fellow adventurers at the Shifting Corridors Lodge Party!\n\n## Details\n\n- **Date:** June 8, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Drop in and out as you please!**\n\n## Who's Invited\n\nAll players, GMs, Venture Officers, and Store Hosts — and their families! If you're part of this community, you're welcome.\n\n## What to Expect\n\nParty games (indoor and outdoor), food, and great company from across the lodge.\n\n## Getting an Invite\n\nThe location is shared privately with your invite. Reach out through any of these:\n\n- **Email:** [lodge@shiftingcorridors.com](mailto:lodge@shiftingcorridors.com)\n- **Discord:** Ask in the server\n- **In person:** Find Marty H or Sam H\n\nNo signup required — just get your invite and show up!\n",
+    "slug": "lodge-party-jun-08-2026",
+    "directory": "calendar"
+  },
+  {
+    "meta": {
       "title": "Pathfinder Society at Geek City Games - Intro: Year of Boundless Wonder",
       "date": "2026-06-07T00:00:00.000Z",
       "url": "/events/gcg-jun-07-2026",


### PR DESCRIPTION
## Summary

- Adds Lodge Party calendar event for June 8, 2026 (5:30–9:30 PM)
- No location or signup URL — invite details shared privately via email, Discord, or Marty H / Sam H

🤖 Generated with [Claude Code](https://claude.com/claude-code)