### PR TITLE
Add Diversions Jun 10 Starfinder session for 2026

### DIFF
--- a/src/content/calendar/diversions-jun-10-2026.md
+++ b/src/content/calendar/diversions-jun-10-2026.md
@@ -1,0 +1,26 @@
+---
+title: Starfinder Society at Diversions - Seize and Destroy
+date: 2026-06-10
+url: /events/diversions-jun-10-2026
+location: Diversions
+address: 119 2nd St #300, Coralville, IA 52241
+---
+
+# Starfinder Society at Diversions
+
+Join us for Starfinder Society games at Diversions in Coralville!
+
+## Details
+
+- **Date:** June 10, 2026
+- **Time:** 6:00 PM Central Time
+- **Location:** Diversions
+- **Address:** 119 2nd St #300, Coralville, IA 52241
+
+## Available Scenarios
+
+1. **Seize and Destroy** (Starfinder Scenario, Levels 1-2) - Starting at 6:00 PM - [Sign up here](https://www.rpgchronicles.net/session/1f67ef56-6b1c-49d0-8436-4806050a87db/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 6 players, so sign up early!


### PR DESCRIPTION
## Summary

- Adds calendar event for Starfinder Society at Diversions on June 10, 2026
- Scenario: *Seize and Destroy* (Levels 1-2), starting at 6:00 PM Central
- Signup via RPG Chronicles

## Test plan

- [ ] Verify event appears on the calendar on the site
- [ ] Confirm signup link routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)