### PR TITLE
Add RSS feed for calendar events

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
+    <link rel="alternate" type="application/rss+xml" title="Shifting Corridors Lodge Calendar" href="/feed.xml" />
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Lora:wght@400;700&family=Orbitron:wght@400;700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <title>Shifting Corridors Lodge</title>
     <!-- Fathom - beautiful, simple website analytics -->

--- a/public/feed.xml
+++ b/public/feed.xml
@@ -1,0 +1,529 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Shifting Corridors Lodge - Calendar</title>
+    <link>https://shiftingcorridors.com</link>
+    <description>Upcoming Pathfinder and Starfinder Society events from the Shifting Corridors Lodge</description>
+    <language>en-us</language>
+    <lastBuildDate>Thu, 04 Jun 2026 16:55:49 GMT</lastBuildDate>
+    <atom:link href="https://shiftingcorridors.com/feed.xml" rel="self" type="application/rss+xml"/>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Lost on the Spirit Road</title>
+      <link>https://shiftingcorridors.com/events/tempest-jun-18-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-jun-18-2026</guid>
+      <pubDate>Sun, 31 May 2026 13:00:26 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Lost on the Spirit Road — Thursday, June 18, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Starfinder Society at Diversions - Seize and Destroy</title>
+      <link>https://shiftingcorridors.com/events/diversions-jun-10-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-jun-10-2026</guid>
+      <pubDate>Thu, 04 Jun 2026 15:25:59 GMT</pubDate>
+      <description>Starfinder Society at Diversions - Seize and Destroy — Wednesday, June 10, 2026 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Replay Games - A Fistful of Flowers</title>
+      <link>https://shiftingcorridors.com/events/replay-jun-09-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/replay-jun-09-2026</guid>
+      <pubDate>Sun, 31 May 2026 13:00:26 GMT</pubDate>
+      <description>Pathfinder Society at Replay Games - A Fistful of Flowers — Tuesday, June 9, 2026 — Replay Games — 617 Center Point Rd NE, Cedar Rapids, IA 52402</description>
+    </item>
+    <item>
+      <title>Shifting Corridors Lodge Party</title>
+      <link>https://shiftingcorridors.com/events/lodge-party-jun-08-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/lodge-party-jun-08-2026</guid>
+      <pubDate>Sun, 31 May 2026 13:17:25 GMT</pubDate>
+      <description>Shifting Corridors Lodge Party — Monday, June 8, 2026</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Intro: Year of Boundless Wonder</title>
+      <link>https://shiftingcorridors.com/events/gcg-jun-07-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-jun-07-2026</guid>
+      <pubDate>Tue, 26 May 2026 14:24:42 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Intro: Year of Boundless Wonder — Sunday, June 7, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - The Dragon Who Stole Evoking Day</title>
+      <link>https://shiftingcorridors.com/events/tempest-jun-04-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-jun-04-2026</guid>
+      <pubDate>Tue, 26 May 2026 13:19:49 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - The Dragon Who Stole Evoking Day — Thursday, June 4, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder &amp; Starfinder Society at Diversions - May 27</title>
+      <link>https://shiftingcorridors.com/events/diversions-may-27-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-may-27-2026</guid>
+      <pubDate>Fri, 01 May 2026 13:21:27 GMT</pubDate>
+      <description>Pathfinder &amp; Starfinder Society at Diversions - May 27 — Wednesday, May 27, 2026 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Starfinder Society at Replay Games - The Great Absalom Relay</title>
+      <link>https://shiftingcorridors.com/events/replay-may-26-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/replay-may-26-2026</guid>
+      <pubDate>Sun, 17 May 2026 14:04:09 GMT</pubDate>
+      <description>Starfinder Society at Replay Games - The Great Absalom Relay — Tuesday, May 26, 2026 — Replay Games — 617 Center Point Rd NE, Cedar Rapids, IA 52402</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - In the Footsteps of Horror</title>
+      <link>https://shiftingcorridors.com/events/tempest-may-21-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-may-21-2026</guid>
+      <pubDate>Mon, 27 Apr 2026 02:53:11 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - In the Footsteps of Horror — Thursday, May 21, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - The Locked Lodge</title>
+      <link>https://shiftingcorridors.com/events/gcg-may-17-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-may-17-2026</guid>
+      <pubDate>Tue, 28 Apr 2026 19:19:18 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - The Locked Lodge — Sunday, May 17, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - May 13</title>
+      <link>https://shiftingcorridors.com/events/diversions-may-13-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-may-13-2026</guid>
+      <pubDate>Tue, 05 May 2026 12:50:21 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - May 13 — Wednesday, May 13, 2026 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Replay Games - A Fistful of Flowers</title>
+      <link>https://shiftingcorridors.com/events/replay-may-12-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/replay-may-12-2026</guid>
+      <pubDate>Wed, 29 Apr 2026 13:55:43 GMT</pubDate>
+      <description>Pathfinder Society at Replay Games - A Fistful of Flowers — Tuesday, May 12, 2026 — Replay Games — 617 Center Point Rd NE, Cedar Rapids, IA 52402</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Perch of Liberty</title>
+      <link>https://shiftingcorridors.com/events/tempest-may-07-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-may-07-2026</guid>
+      <pubDate>Mon, 27 Apr 2026 02:53:11 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Perch of Liberty — Thursday, May 7, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Struck by Shadows</title>
+      <link>https://shiftingcorridors.com/events/gcg-may-03-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-may-03-2026</guid>
+      <pubDate>Mon, 27 Apr 2026 02:53:11 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Struck by Shadows — Sunday, May 3, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - The Great Toy Heist</title>
+      <link>https://shiftingcorridors.com/events/tempest-apr-30-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-apr-30-2026</guid>
+      <pubDate>Mon, 06 Apr 2026 17:45:57 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - The Great Toy Heist — Thursday, April 30, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Replay Games - Decilane Academy's Delightful Disaster</title>
+      <link>https://shiftingcorridors.com/events/replay-apr-28-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/replay-apr-28-2026</guid>
+      <pubDate>Sun, 19 Apr 2026 13:31:14 GMT</pubDate>
+      <description>Pathfinder Society at Replay Games - Decilane Academy's Delightful Disaster — Tuesday, April 28, 2026 — Replay Games — 617 Center Point Rd NE, Cedar Rapids, IA 52402</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - To Seek The Heart of Calamity</title>
+      <link>https://shiftingcorridors.com/events/gcg-apr-19-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-apr-19-2026</guid>
+      <pubDate>Thu, 26 Mar 2026 04:09:21 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - To Seek The Heart of Calamity — Sunday, April 19, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Lions of Katapesh</title>
+      <link>https://shiftingcorridors.com/events/tempest-apr-16-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-apr-16-2026</guid>
+      <pubDate>Mon, 06 Apr 2026 17:45:57 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Lions of Katapesh — Thursday, April 16, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Replay Games - A Star's Journey</title>
+      <link>https://shiftingcorridors.com/events/replay-apr-14-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/replay-apr-14-2026</guid>
+      <pubDate>Sat, 04 Apr 2026 16:41:33 GMT</pubDate>
+      <description>Pathfinder Society at Replay Games - A Star's Journey — Tuesday, April 14, 2026 — Replay Games — 617 Center Point Rd NE, Cedar Rapids, IA 52402</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - April 8</title>
+      <link>https://shiftingcorridors.com/events/diversions-apr-08-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-apr-08-2026</guid>
+      <pubDate>Wed, 01 Apr 2026 16:39:59 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - April 8 — Wednesday, April 8, 2026 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Wayfinder Origins</title>
+      <link>https://shiftingcorridors.com/events/tempest-apr-02-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-apr-02-2026</guid>
+      <pubDate>Mon, 30 Mar 2026 14:03:21 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Wayfinder Origins — Thursday, April 2, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Replay Games - Winter Queen's Dollhouse</title>
+      <link>https://shiftingcorridors.com/events/replay-mar-31-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/replay-mar-31-2026</guid>
+      <pubDate>Thu, 26 Mar 2026 04:09:21 GMT</pubDate>
+      <description>Pathfinder Society at Replay Games - Winter Queen's Dollhouse — Tuesday, March 31, 2026 — Replay Games — 617 Center Point Rd NE, Cedar Rapids, IA 52402</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Inheritor's Rite</title>
+      <link>https://shiftingcorridors.com/events/gcg-mar-29-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-mar-29-2026</guid>
+      <pubDate>Tue, 03 Mar 2026 16:43:17 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Inheritor's Rite — Sunday, March 29, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder &amp; Starfinder Society at Diversions - March 25</title>
+      <link>https://shiftingcorridors.com/events/diversions-mar-25-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-mar-25-2026</guid>
+      <pubDate>Wed, 11 Mar 2026 21:55:44 GMT</pubDate>
+      <description>Pathfinder &amp; Starfinder Society at Diversions - March 25 — Wednesday, March 25, 2026 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Tanuki Trouble</title>
+      <link>https://shiftingcorridors.com/events/tempest-mar-19-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-mar-19-2026</guid>
+      <pubDate>Sun, 08 Mar 2026 23:41:33 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Tanuki Trouble — Thursday, March 19, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Replay Games - The Mosquito Witch</title>
+      <link>https://shiftingcorridors.com/events/replay-mar-17-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/replay-mar-17-2026</guid>
+      <pubDate>Tue, 03 Mar 2026 17:24:19 GMT</pubDate>
+      <description>Pathfinder Society at Replay Games - The Mosquito Witch — Tuesday, March 17, 2026 — Replay Games — 617 Center Point Rd NE, Cedar Rapids, IA 52402</description>
+    </item>
+    <item>
+      <title>Gamicon Bromine - Day 3</title>
+      <link>https://shiftingcorridors.com/events/gamicon-bromine-mar-08-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gamicon-bromine-mar-08-2026</guid>
+      <pubDate>Sat, 21 Feb 2026 13:21:03 GMT</pubDate>
+      <description>Gamicon Bromine - Day 3 — Sunday, March 8, 2026 — Hyatt Regency Coralville Hotel &amp; Conference Center — 300 E 9th St, Coralville, IA 52241, USA</description>
+    </item>
+    <item>
+      <title>Gamicon Bromine - Day 2</title>
+      <link>https://shiftingcorridors.com/events/gamicon-bromine-mar-07-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gamicon-bromine-mar-07-2026</guid>
+      <pubDate>Thu, 12 Feb 2026 14:39:17 GMT</pubDate>
+      <description>Gamicon Bromine - Day 2 — Saturday, March 7, 2026 — Hyatt Regency Coralville Hotel &amp; Conference Center — 300 E 9th St, Coralville, IA 52241, USA</description>
+    </item>
+    <item>
+      <title>Gamicon Bromine - Day 1</title>
+      <link>https://shiftingcorridors.com/events/gamicon-bromine-mar-06-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gamicon-bromine-mar-06-2026</guid>
+      <pubDate>Mon, 16 Feb 2026 02:34:56 GMT</pubDate>
+      <description>Gamicon Bromine - Day 1 — Friday, March 6, 2026 — Hyatt Regency Coralville Hotel &amp; Conference Center — 300 E 9th St, Coralville, IA 52241, USA</description>
+    </item>
+    <item>
+      <title>Pathfinder &amp; Starfinder Society at Diversions - February 25</title>
+      <link>https://shiftingcorridors.com/events/diversions-feb-25-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-feb-25-2026</guid>
+      <pubDate>Tue, 24 Feb 2026 23:22:31 GMT</pubDate>
+      <description>Pathfinder &amp; Starfinder Society at Diversions - February 25 — Wednesday, February 25, 2026 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Port Peril Pub Crawl</title>
+      <link>https://shiftingcorridors.com/events/tempest-feb-19-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-feb-19-2026</guid>
+      <pubDate>Sat, 31 Jan 2026 15:49:49 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Port Peril Pub Crawl — Thursday, February 19, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - The Devil-Wrought Disappearance</title>
+      <link>https://shiftingcorridors.com/events/gcg-feb-15-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-feb-15-2026</guid>
+      <pubDate>Sun, 18 Jan 2026 05:06:26 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - The Devil-Wrought Disappearance — Sunday, February 15, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - February 11</title>
+      <link>https://shiftingcorridors.com/events/diversions-feb-11-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-feb-11-2026</guid>
+      <pubDate>Tue, 03 Feb 2026 13:46:22 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - February 11 — Wednesday, February 11, 2026 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Lacking Respect</title>
+      <link>https://shiftingcorridors.com/events/tempest-feb-05-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-feb-05-2026</guid>
+      <pubDate>Mon, 19 Jan 2026 04:01:30 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Lacking Respect — Thursday, February 5, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Devil at the Crossroads</title>
+      <link>https://shiftingcorridors.com/events/gcg-feb-01-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-feb-01-2026</guid>
+      <pubDate>Sun, 18 Jan 2026 05:06:26 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Devil at the Crossroads — Sunday, February 1, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Escort a Mirage</title>
+      <link>https://shiftingcorridors.com/events/tempest-jan-29-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-jan-29-2026</guid>
+      <pubDate>Fri, 16 Jan 2026 16:07:09 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Escort a Mirage — Thursday, January 29, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder &amp; Starfinder Society at Diversions - January 28</title>
+      <link>https://shiftingcorridors.com/events/diversions-jan-28-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-jan-28-2026</guid>
+      <pubDate>Wed, 07 Jan 2026 14:13:05 GMT</pubDate>
+      <description>Pathfinder &amp; Starfinder Society at Diversions - January 28 — Wednesday, January 28, 2026 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - The East Hill Haunting</title>
+      <link>https://shiftingcorridors.com/events/gcg-jan-18-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-jan-18-2026</guid>
+      <pubDate>Sat, 13 Dec 2025 15:08:58 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - The East Hill Haunting — Sunday, January 18, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Within the Glacier</title>
+      <link>https://shiftingcorridors.com/events/tempest-jan-15-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-jan-15-2026</guid>
+      <pubDate>Fri, 09 Jan 2026 15:19:37 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Within the Glacier — Thursday, January 15, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - January 14</title>
+      <link>https://shiftingcorridors.com/events/diversions-jan-14-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-jan-14-2026</guid>
+      <pubDate>Tue, 30 Dec 2025 14:49:04 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - January 14 — Wednesday, January 14, 2026 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Intro: Year of Shattered Sanctuaries</title>
+      <link>https://shiftingcorridors.com/events/gcg-jan-04-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-jan-04-2026</guid>
+      <pubDate>Sat, 27 Dec 2025 15:59:12 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Intro: Year of Shattered Sanctuaries — Sunday, January 4, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Silver Bark, Golden Blades</title>
+      <link>https://shiftingcorridors.com/events/tempest-jan-01-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-jan-01-2026</guid>
+      <pubDate>Sun, 14 Dec 2025 14:15:40 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Silver Bark, Golden Blades — Thursday, January 1, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder &amp; Starfinder Society at Diversions - December 24</title>
+      <link>https://shiftingcorridors.com/events/diversions-dec-24-2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-dec-24-2025</guid>
+      <pubDate>Fri, 05 Dec 2025 13:19:10 GMT</pubDate>
+      <description>Pathfinder &amp; Starfinder Society at Diversions - December 24 — Wednesday, December 24, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - The Elsewhere Feast</title>
+      <link>https://shiftingcorridors.com/events/tempest-dragon-evoking-day</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-dragon-evoking-day</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - The Elsewhere Feast — Thursday, December 18, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - December 10</title>
+      <link>https://shiftingcorridors.com/events/diversions-dec-10-2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-dec-10-2025</guid>
+      <pubDate>Fri, 05 Dec 2025 13:19:10 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - December 10 — Wednesday, December 10, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Dinner at Lionlodge</title>
+      <link>https://shiftingcorridors.com/events/gcg-dinner-lionlodge</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-dinner-lionlodge</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Dinner at Lionlodge — Sunday, December 7, 2025 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - The Greengold Dilemma</title>
+      <link>https://shiftingcorridors.com/events/tempest-greengold-dilemma</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-greengold-dilemma</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - The Greengold Dilemma — Thursday, December 4, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - November 26</title>
+      <link>https://shiftingcorridors.com/events/diversions-nov-26-2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-nov-26-2025</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - November 26 — Wednesday, November 26, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Second Confirmation</title>
+      <link>https://shiftingcorridors.com/events/tempest-second-confirmation-nov</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-second-confirmation-nov</guid>
+      <pubDate>Fri, 21 Nov 2025 15:28:29 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Second Confirmation — Sunday, November 23, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - The Sandstone Secret</title>
+      <link>https://shiftingcorridors.com/events/tempest-sandstone-secret</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-sandstone-secret</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - The Sandstone Secret — Thursday, November 20, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - November 12</title>
+      <link>https://shiftingcorridors.com/events/diversions-nov-12-2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-nov-12-2025</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - November 12 — Wednesday, November 12, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Student Exchange</title>
+      <link>https://shiftingcorridors.com/events/tempest-student-exchange</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-student-exchange</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Student Exchange — Thursday, November 6, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Mark of the Mantis</title>
+      <link>https://shiftingcorridors.com/events/gcg-mark-of-mantis</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-mark-of-mantis</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Mark of the Mantis — Sunday, November 2, 2025 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - The Swordlord's Challenge</title>
+      <link>https://shiftingcorridors.com/events/tempest-swordlords-challenge</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-swordlords-challenge</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - The Swordlord's Challenge — Thursday, October 30, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder &amp; Starfinder Society at Diversions - October 22</title>
+      <link>https://shiftingcorridors.com/events/diversions-oct-22-2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-oct-22-2025</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder &amp; Starfinder Society at Diversions - October 22 — Wednesday, October 22, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Fury's Toll</title>
+      <link>https://shiftingcorridors.com/events/gcg-furys-toll-oct</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-furys-toll-oct</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Fury's Toll — Sunday, October 19, 2025 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - The Winter Queen's Dollhouse</title>
+      <link>https://shiftingcorridors.com/events/tempest-winter-queen-dollhouse</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-winter-queen-dollhouse</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - The Winter Queen's Dollhouse — Thursday, October 2, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder &amp; Starfinder Society at Diversions - September 24</title>
+      <link>https://shiftingcorridors.com/events/diversions-sep-24-2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-sep-24-2025</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder &amp; Starfinder Society at Diversions - September 24 — Wednesday, September 24, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Fury's Toll</title>
+      <link>https://shiftingcorridors.com/events/gcg-furys-toll</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-furys-toll</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Fury's Toll — Sunday, September 21, 2025 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Infernal Infiltration</title>
+      <link>https://shiftingcorridors.com/events/tempest-infernal-infiltration</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-infernal-infiltration</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Infernal Infiltration — Thursday, September 18, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - September 10</title>
+      <link>https://shiftingcorridors.com/events/diversions-sep-10-2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-sep-10-2025</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - September 10 — Wednesday, September 10, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Sewer Dragon Crisis</title>
+      <link>https://shiftingcorridors.com/events/gcg-sewer-dragon-crisis</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-sewer-dragon-crisis</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Sewer Dragon Crisis — Sunday, September 7, 2025 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - The Dacilane Academy's Show Must Go On</title>
+      <link>https://shiftingcorridors.com/events/tempest-dacilane-academy</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-dacilane-academy</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - The Dacilane Academy's Show Must Go On — Thursday, September 4, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder &amp; Starfinder Society at Diversions - August 27</title>
+      <link>https://shiftingcorridors.com/events/diversions-aug-27-2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-aug-27-2025</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder &amp; Starfinder Society at Diversions - August 27 — Wednesday, August 27, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - Friends in Need</title>
+      <link>https://shiftingcorridors.com/events/tempest-friends-need</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-friends-need</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - Friends in Need — Thursday, August 21, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - August 13</title>
+      <link>https://shiftingcorridors.com/events/diversions-aug-13-2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-aug-13-2025</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - August 13 — Wednesday, August 13, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Tempest Games - In the Footsteps of Horror</title>
+      <link>https://shiftingcorridors.com/events/tempest-footsteps-horror</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-footsteps-horror</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Tempest Games - In the Footsteps of Horror — Thursday, August 7, 2025 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Starfinder Society at Diversions - Battle for Nova Rush</title>
+      <link>https://shiftingcorridors.com/events/diversions-battle-nova-rush</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-battle-nova-rush</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Starfinder Society at Diversions - Battle for Nova Rush — Wednesday, July 23, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - Mischief in the Maze</title>
+      <link>https://shiftingcorridors.com/events/diversions-mischief-maze</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-mischief-maze</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - Mischief in the Maze — Wednesday, July 23, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games</title>
+      <link>https://shiftingcorridors.com/events/gcg-13Jul2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-13Jul2025</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games — Sunday, July 13, 2025 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - Second Confirmation</title>
+      <link>https://shiftingcorridors.com/events/diversions-second-confirmation</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-second-confirmation</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - Second Confirmation — Wednesday, July 9, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions - Year of Immortal Influence Intro</title>
+      <link>https://shiftingcorridors.com/events/diversions-symposium-fallen-god</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-symposium-fallen-god</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Diversions - Year of Immortal Influence Intro — Wednesday, July 9, 2025 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games</title>
+      <link>https://shiftingcorridors.com/events/gcg-29Jun2025</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-29Jun2025</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games — Sunday, June 29, 2025 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Diversions</title>
+      <link>https://shiftingcorridors.com/events/diversions-game-night</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-game-night</guid>
+      <pubDate>Wed, 19 Nov 2025 16:48:03 GMT</pubDate>
+      <description>Pathfinder Society at Diversions — Wednesday, June 25, 2025 — Diversions — 119 2nd St</description>
+    </item>
+  </channel>
+</rss>

--- a/scripts/build-content.js
+++ b/scripts/build-content.js
@@ -3,6 +3,7 @@
 const fs = require('fs').promises;
 const path = require('path');
 const matter = require('gray-matter');
+const { execSync } = require('child_process');
 
 /**
  * Build script to convert markdown content to JSON data
@@ -11,6 +12,7 @@ const matter = require('gray-matter');
 
 const CONTENT_DIR = path.join(__dirname, '../src/content');
 const OUTPUT_DIR = path.join(__dirname, '../src/data');
+const PUBLIC_DIR = path.join(__dirname, '../public');
 
 async function ensureDir(dir) {
   try {
@@ -20,23 +22,90 @@ async function ensureDir(dir) {
   }
 }
 
+function getGitCommitDate(filePath) {
+  try {
+    const result = execSync(`git log --follow -1 --format="%aI" -- "${filePath}"`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return result ? new Date(result) : new Date();
+  } catch {
+    return new Date();
+  }
+}
+
+function escapeXml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 async function processMarkdownFile(filePath, directory) {
   try {
     const content = await fs.readFile(filePath, 'utf-8');
     const { data: meta, content: markdownContent } = matter(content);
-    
+
     const fileName = path.basename(filePath, '.md');
-    
+
     return {
       meta,
       content: markdownContent,
       slug: fileName,
-      directory
+      directory,
+      gitDate: getGitCommitDate(filePath),
     };
   } catch (error) {
     console.error(`Error processing ${filePath}:`, error.message);
     throw error;
   }
+}
+
+async function buildRssFeed(calendarData) {
+  const SITE_URL = process.env.SITE_URL || 'https://shiftingcorridors.com';
+  const now = new Date();
+
+  const items = calendarData
+    .filter(item => item.meta.date && item.meta.url)
+    .map(item => {
+      const eventUrl = `${SITE_URL}${item.meta.url}`;
+      const pubDate = (item.gitDate || now).toUTCString();
+
+      const descParts = [item.meta.title];
+      if (item.meta.date) {
+        const d = new Date(item.meta.date);
+        descParts.push(d.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }));
+      }
+      if (item.meta.location) descParts.push(item.meta.location);
+      if (item.meta.address) descParts.push(item.meta.address);
+
+      return `    <item>
+      <title>${escapeXml(item.meta.title)}</title>
+      <link>${escapeXml(eventUrl)}</link>
+      <guid isPermaLink="true">${escapeXml(eventUrl)}</guid>
+      <pubDate>${pubDate}</pubDate>
+      <description>${escapeXml(descParts.join(' — '))}</description>
+    </item>`;
+    })
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Shifting Corridors Lodge - Calendar</title>
+    <link>${escapeXml(SITE_URL)}</link>
+    <description>Upcoming Pathfinder and Starfinder Society events from the Shifting Corridors Lodge</description>
+    <language>en-us</language>
+    <lastBuildDate>${now.toUTCString()}</lastBuildDate>
+    <atom:link href="${escapeXml(`${SITE_URL}/feed.xml`)}" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+  const outputPath = path.join(PUBLIC_DIR, 'feed.xml');
+  await fs.writeFile(outputPath, xml);
+  console.log(`✅ Created ${outputPath} with ${calendarData.length} items`);
 }
 
 async function processDirectory(directory) {
@@ -69,14 +138,19 @@ async function buildContent() {
   
   const directories = ['calendar', 'news', 'gamemasters'];
   
+  const builtData = {};
   for (const directory of directories) {
     console.log(`📁 Processing ${directory}...`);
     const data = await processDirectory(directory);
+    builtData[directory] = data;
     const outputPath = path.join(OUTPUT_DIR, `${directory}.json`);
     await fs.writeFile(outputPath, JSON.stringify(data, null, 2));
     console.log(`✅ Created ${outputPath} with ${data.length} items`);
   }
-  
+
+  console.log('📡 Building RSS feed...');
+  await buildRssFeed(builtData.calendar);
+
   console.log('🎉 Content build complete!');
 }
 

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -114,6 +114,26 @@ const StyledCalendarContainer = styled.div<{ theme: any }>`
     font-weight: bold;
     cursor: pointer;
   }
+
+  .calendar-title-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 0;
+  }
+
+  .rss-link {
+    display: flex;
+    align-items: center;
+    color: #f26522;
+    text-decoration: none;
+    opacity: 0.85;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
 `;
 
 // Helper functions for date manipulation without moment.js
@@ -248,9 +268,17 @@ const CalendarComponent: React.FC<CalendarComponentProps> = ({ events = [] }) =>
 
   return (
     <StyledCalendarContainer theme={theme}>
-      <h2 style={{ fontFamily: theme.fonts.heading, color: theme.colors.primary }}>
-        Event Calendar
-      </h2>
+      <div className="calendar-title-row">
+        <h2 style={{ fontFamily: theme.fonts.heading, color: theme.colors.primary, margin: 0 }}>
+          Event Calendar
+        </h2>
+        <a className="rss-link" href="/feed.xml" title="Subscribe to calendar RSS feed" aria-label="RSS feed">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="currentColor">
+            <circle cx="6.18" cy="17.82" r="2.18"/>
+            <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/>
+          </svg>
+        </a>
+      </div>
       
       <div className="calendar-header">
         <button className="calendar-nav-button" onClick={prevMonth}>


### PR DESCRIPTION
## Summary

- Adds `public/feed.xml` generated at build time from calendar content
- Uses git commit date as `<pubDate>` so feed readers surface newly added or updated events
- Base URL defaults to `https://shiftingcorridors.com`; can be overridden with `SITE_URL` env var for dev deploys
- Adds `<link rel="alternate">` autodiscovery tag to `index.html`

## Test plan

- [ ] Deploy to dev (`SITE_URL=https://dev.shiftingcorridors.com npm run build`)
- [ ] Verify `https://dev.shiftingcorridors.com/feed.xml` is accessible
- [ ] Subscribe to the feed in a feed reader and confirm events appear with correct dates and links
- [ ] Add a new calendar event, rebuild, and confirm it appears at the top of the feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)