### PR TITLE
Add Jun 10 Pathfinder scenario and Jun 24 Diversions double-header

### DIFF
--- a/public/feed.xml
+++ b/public/feed.xml
@@ -5,8 +5,15 @@
     <link>https://shiftingcorridors.com</link>
     <description>Upcoming Pathfinder and Starfinder Society events from the Shifting Corridors Lodge</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 04 Jun 2026 16:55:49 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 05 Jun 2026 00:27:28 GMT</lastBuildDate>
     <atom:link href="https://shiftingcorridors.com/feed.xml" rel="self" type="application/rss+xml"/>
+    <item>
+      <title>Pathfinder &amp; Starfinder Society at Diversions - Jun 24</title>
+      <link>https://shiftingcorridors.com/events/diversions-jun-24-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-jun-24-2026</guid>
+      <pubDate>Fri, 05 Jun 2026 00:27:28 GMT</pubDate>
+      <description>Pathfinder &amp; Starfinder Society at Diversions - Jun 24 — Wednesday, June 24, 2026 — Diversions — 119 2nd St</description>
+    </item>
     <item>
       <title>Pathfinder Society at Tempest Games - Lost on the Spirit Road</title>
       <link>https://shiftingcorridors.com/events/tempest-jun-18-2026</link>
@@ -15,11 +22,11 @@
       <description>Pathfinder Society at Tempest Games - Lost on the Spirit Road — Thursday, June 18, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
     </item>
     <item>
-      <title>Starfinder Society at Diversions - Seize and Destroy</title>
+      <title>Pathfinder &amp; Starfinder Society at Diversions - Jun 10</title>
       <link>https://shiftingcorridors.com/events/diversions-jun-10-2026</link>
       <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-jun-10-2026</guid>
       <pubDate>Thu, 04 Jun 2026 15:25:59 GMT</pubDate>
-      <description>Starfinder Society at Diversions - Seize and Destroy — Wednesday, June 10, 2026 — Diversions — 119 2nd St</description>
+      <description>Pathfinder &amp; Starfinder Society at Diversions - Jun 10 — Wednesday, June 10, 2026 — Diversions — 119 2nd St</description>
     </item>
     <item>
       <title>Pathfinder Society at Replay Games - A Fistful of Flowers</title>

--- a/src/content/calendar/diversions-jun-24-2026.md
+++ b/src/content/calendar/diversions-jun-24-2026.md
@@ -1,7 +1,7 @@
 ---
-title: Pathfinder & Starfinder Society at Diversions - Jun 10
-date: 2026-06-10
-url: /events/diversions-jun-10-2026
+title: Pathfinder & Starfinder Society at Diversions - Jun 24
+date: 2026-06-24
+url: /events/diversions-jun-24-2026
 location: Diversions
 address: 119 2nd St #300, Coralville, IA 52241
 ---
@@ -12,7 +12,7 @@ Join us for Pathfinder and Starfinder Society games at Diversions in Coralville!
 
 ## Details
 
-- **Date:** June 10, 2026
+- **Date:** June 24, 2026
 - **Time:** 5:30 PM - 9:30 PM Central Time
 - **Location:** Diversions
 - **Address:** 119 2nd St #300, Coralville, IA 52241
@@ -20,10 +20,10 @@ Join us for Pathfinder and Starfinder Society games at Diversions in Coralville!
 ## Available Scenarios
 
 ### Pathfinder Society
-1. **Strings of Hell** (Levels 1-2, starts 5:30 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/83b43a5c-1257-4316-b94f-04a50ee8dcc6/pregame)
+1. **Guardian's Covenant** (Levels 3-6, starts 5:30 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/9d40025a-0eb4-4738-a499-929137cdfc6b/pregame)
 
 ### Starfinder Society
-1. **Compliance Protocol** (Levels 1-2, starts 6:00 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/1f67ef56-6b1c-49d0-8436-4806050a87db/pregame)
+1. **Psychic Echoes** (Levels 1-2, starts 6:00 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/f3b2abc9-653b-439a-8a1c-7dc6d490c11e/pregame)
 
 ## Registration
 

--- a/src/data/calendar.json
+++ b/src/data/calendar.json
@@ -1,6 +1,19 @@
 [
   {
     "meta": {
+      "title": "Pathfinder & Starfinder Society at Diversions - Jun 24",
+      "date": "2026-06-24T00:00:00.000Z",
+      "url": "/events/diversions-jun-24-2026",
+      "location": "Diversions",
+      "address": "119 2nd St"
+    },
+    "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** June 24, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n### Pathfinder Society\n1. **Guardian's Covenant** (Levels 3-6, starts 5:30 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/9d40025a-0eb4-4738-a499-929137cdfc6b/pregame)\n\n### Starfinder Society\n1. **Psychic Echoes** (Levels 1-2, starts 6:00 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/f3b2abc9-653b-439a-8a1c-7dc6d490c11e/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!\n",
+    "slug": "diversions-jun-24-2026",
+    "directory": "calendar",
+    "gitDate": "2026-06-05T00:27:28.624Z"
+  },
+  {
+    "meta": {
       "title": "Pathfinder Society at Tempest Games - Lost on the Spirit Road",
       "date": "2026-06-18T00:00:00.000Z",
       "url": "/events/tempest-jun-18-2026",
@@ -9,7 +22,21 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** June 18, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 5 players\n\n## Available Scenarios\n\n1. **Lost on the Spirit Road** (Pathfinder Scenario, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/83a58b66-f5eb-45f3-ad6c-c825b2113bd3/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 5 players, so sign up early!\n",
     "slug": "tempest-jun-18-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-05-31T13:00:26.000Z"
+  },
+  {
+    "meta": {
+      "title": "Pathfinder & Starfinder Society at Diversions - Jun 10",
+      "date": "2026-06-10T00:00:00.000Z",
+      "url": "/events/diversions-jun-10-2026",
+      "location": "Diversions",
+      "address": "119 2nd St"
+    },
+    "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** June 10, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n### Pathfinder Society\n1. **Strings of Hell** (Levels 1-2, starts 5:30 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/83b43a5c-1257-4316-b94f-04a50ee8dcc6/pregame)\n\n### Starfinder Society\n1. **Compliance Protocol** (Levels 1-2, starts 6:00 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/1f67ef56-6b1c-49d0-8436-4806050a87db/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!\n",
+    "slug": "diversions-jun-10-2026",
+    "directory": "calendar",
+    "gitDate": "2026-06-04T15:25:59.000Z"
   },
   {
     "meta": {
@@ -21,7 +48,8 @@
     },
     "content": "\n# Pathfinder Society at Replay Games\n\nJoin us for Pathfinder Society games at Replay Games in Cedar Rapids!\n\n## Details\n\n- **Date:** June 9, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Replay Games\n- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402\n- **Players:** 4 players\n\n## Available Scenarios\n\n1. **A Fistful of Flowers** (Pathfinder Scenario, Pregenerated Characters) - [Sign up here](https://www.rpgchronicles.net/session/1ec0a5dd-465e-438c-9dc8-6b31949859fa/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 4 players, so sign up early!\n\n> **Note:** This scenario uses pregenerated characters — no personal character needed!\n",
     "slug": "replay-jun-09-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-05-31T13:00:26.000Z"
   },
   {
     "meta": {
@@ -31,7 +59,8 @@
     },
     "content": "\n# Shifting Corridors Lodge Party\n\nCome celebrate with your fellow adventurers at the Shifting Corridors Lodge Party!\n\n## Details\n\n- **Date:** June 8, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Drop in and out as you please!**\n\n## Who's Invited\n\nAll players, GMs, Venture Officers, and Store Hosts — and their families! If you're part of this community, you're welcome.\n\n## What to Expect\n\nParty games (indoor and outdoor), food, and great company from across the lodge.\n\n## Getting an Invite\n\nThe location is shared privately with your invite. Reach out through any of these:\n\n- **Email:** [lodge@shiftingcorridors.com](mailto:lodge@shiftingcorridors.com)\n- **Discord:** Ask in the server\n- **In person:** Find Marty H or Sam H\n\nNo signup required — just get your invite and show up!\n",
     "slug": "lodge-party-jun-08-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-05-31T13:17:25.000Z"
   },
   {
     "meta": {
@@ -43,7 +72,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** June 7, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **Intro: Year of Boundless Wonder** (Pathfinder Scenario) - [Sign up here](https://www.rpgchronicles.net/session/c5df7e83-d63f-46dc-8ce7-5a432d5d29e2/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!\n",
     "slug": "gcg-jun-07-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-05-26T14:24:42.000Z"
   },
   {
     "meta": {
@@ -55,7 +85,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** June 4, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 5 players\n\n## Available Scenarios\n\n1. **The Dragon Who Stole Evoking Day** (Pathfinder Quest) - [Sign up here](https://www.rpgchronicles.net/session/bea133d4-29bf-46dc-9008-bad825b4ea19/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 5 players, so sign up early!\n",
     "slug": "tempest-jun-04-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-05-26T13:19:49.000Z"
   },
   {
     "meta": {
@@ -67,7 +98,8 @@
     },
     "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** May 27, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n### Pathfinder Society\n1. **Path of Kings** (Levels 3-6, starts 5:30 PM) - [Sign up here](https://www.rpgchronicles.net/session/430856d0-e7d0-4768-9535-75bab1319ac0/pregame)\n\n### Starfinder Society\n1. **Friends of the Forest** (Levels 1-2, starts 6:00 PM, 5 players) - [Sign up here](https://www.rpgchronicles.net/session/6eca1c83-851f-4ff0-8538-5763a77cc3db/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!\n",
     "slug": "diversions-may-27-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-05-01T13:21:27.000Z"
   },
   {
     "meta": {
@@ -79,7 +111,8 @@
     },
     "content": "\n# Starfinder Society at Replay Games\n\nJoin us for Starfinder Society games at Replay Games in Cedar Rapids!\n\n## Details\n\n- **Date:** May 26, 2026\n- **Time:** 5:30 PM - 9:00 PM Central Time\n- **Location:** Replay Games\n- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402\n\n## Available Scenarios\n\n1. **The Great Absalom Relay** (Starfinder 2E Scenario) - [Sign up here](https://www.rpgchronicles.net/session/0966a386-c88a-46e6-bf70-c275169c493d/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 5 players, so sign up early!\n",
     "slug": "replay-may-26-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-05-17T14:04:09.000Z"
   },
   {
     "meta": {
@@ -91,7 +124,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** May 21, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n\n## Available Scenarios\n\n1. **In the Footsteps of Horror** (Pathfinder Quest) - [Sign up here](https://www.rpgchronicles.net/session/40bcae81-4d6c-4c0b-8e86-25702baf291f/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!\n",
     "slug": "tempest-may-21-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-04-27T02:53:11.000Z"
   },
   {
     "meta": {
@@ -103,7 +137,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** May 17, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **The Locked Lodge** (Pathfinder Scenario, Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/bceae215-3def-4eb8-b9a8-54651abc47e9/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!\n",
     "slug": "gcg-may-17-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-04-28T19:19:18.000Z"
   },
   {
     "meta": {
@@ -115,7 +150,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** May 13, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **The Crocodile's Smile** (Levels 1-4) - **5:30 PM** - [Sign up here](https://www.rpgchronicles.net/session/7406a021-43f0-4d9a-9384-42bb6b8dad70/pregame)\n2. **Perch of Liberty** (Levels 3-4) - **6:00 PM** - [Sign up here](https://www.rpgchronicles.net/session/2afeb9c2-b4b3-4d9c-badf-57df083645be/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!\n",
     "slug": "diversions-may-13-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-05-05T12:50:21.000Z"
   },
   {
     "meta": {
@@ -127,7 +163,8 @@
     },
     "content": "\n# Pathfinder Society at Replay Games\n\nJoin us for Pathfinder Society games at Replay Games in Cedar Rapids!\n\n## Details\n\n- **Date:** May 12, 2026\n- **Time:** 5:30 PM - 9:00 PM Central Time\n- **Location:** Replay Games\n- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402\n\n## Available Scenarios\n\n1. **A Fistful of Flowers** (Pathfinder Scenario, Pregenerated Characters) - [Sign up here](https://www.rpgchronicles.net/session/884b3aaa-b81c-466e-82db-7c9dbdc5afe4/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 4 players per game, so sign up early!\n\n> **Note:** This scenario uses pregenerated characters — no personal character needed!\n",
     "slug": "replay-may-12-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-04-29T13:55:43.000Z"
   },
   {
     "meta": {
@@ -139,7 +176,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** May 7, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 5 players\n- **Level Range:** 3-4\n\n## Available Scenarios\n\n1. **Perch of Liberty** (Pathfinder Scenario, Levels 3-4) - [Sign up here](https://www.rpgchronicles.net/session/396e19f6-4704-43c9-a782-3b8b75532304/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 5 players, so sign up early!\n",
     "slug": "tempest-may-07-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-04-27T02:53:11.000Z"
   },
   {
     "meta": {
@@ -151,7 +189,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** May 3, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **Struck by Shadows** (Pathfinder Scenario, Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/274f9926-e147-4f7f-bc85-d280e694e5f9/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!\n",
     "slug": "gcg-may-03-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-04-27T02:53:11.000Z"
   },
   {
     "meta": {
@@ -163,7 +202,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** April 30, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 4 players\n\n## Available Scenarios\n\n1. **The Great Toy Heist** (Pathfinder Scenario) - [Sign up here](https://www.rpgchronicles.net/session/a39e7feb-9a3d-4787-8a75-4083a24d70e8/pregame)\n\n> **Special Note:** This scenario uses pregenerated characters. The chronicle can be applied to any character you own, regardless of level.\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 4 players, so sign up early!\n",
     "slug": "tempest-apr-30-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-04-06T17:45:57.000Z"
   },
   {
     "meta": {
@@ -175,7 +215,8 @@
     },
     "content": "\n# Pathfinder Society at Replay Games\n\nJoin us for Pathfinder Society games at Replay Games in Cedar Rapids!\n\n## Details\n\n- **Date:** April 28, 2026\n- **Time:** 5:30 PM - 9:00 PM Central Time\n- **Location:** Replay Games\n- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402\n\n## Available Scenarios\n\n1. **Decilane Academy's Delightful Disaster** (Pathfinder Scenario, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/bc9d4fd3-7099-4001-a53d-08d0e7e6d9e4/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 5 players per game, so sign up early!\n",
     "slug": "replay-apr-28-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-04-19T13:31:14.000Z"
   },
   {
     "meta": {
@@ -187,7 +228,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** April 19, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **To Seek The Heart of Calamity** (Pathfinder Scenario, Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/ec3d52a3-6088-4f20-a5e6-792dfd170eae/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!\n",
     "slug": "gcg-apr-19-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-03-26T04:09:21.000Z"
   },
   {
     "meta": {
@@ -199,7 +241,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** April 16, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **Lions of Katapesh** (Pathfinder Scenario, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/8e61c61b-59b1-4c9b-b95c-be910b4534ad/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!\n",
     "slug": "tempest-apr-16-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-04-06T17:45:57.000Z"
   },
   {
     "meta": {
@@ -211,7 +254,8 @@
     },
     "content": "\n# Pathfinder Society at Replay Games\n\nJoin us for Pathfinder Society games at Replay Games in Cedar Rapids!\n\n## Details\n\n- **Date:** April 14, 2026\n- **Time:** 5:30 PM - 9:00 PM Central Time\n- **Location:** Replay Games\n- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402\n\n## Available Scenarios\n\n1. **A Star's Journey** (Pathfinder Scenario, Levels 1-2) - [Sign up here](https://www.rpgchronicles.net/session/992edf19-141f-4de0-b065-bbdb9ed2c1aa/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 5 players per game, so sign up early!\n",
     "slug": "replay-apr-14-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-04-04T16:41:33.000Z"
   },
   {
     "meta": {
@@ -223,7 +267,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** April 8, 2026\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Sewer Dragon Crisis** (Pathfinder Scenario, Levels 1-4) - **5:30 PM - 9:30 PM** - [Sign up here](https://www.rpgchronicles.net/session/074df87e-737d-4d38-9c25-1e4b6a92b71d/pregame)\n2. **Mountain of Sea and Sky** (Pathfinder Scenario, Levels 3-6) - **5:30 PM - 9:30 PM** - [Sign up here](https://www.rpgchronicles.net/session/db55995b-780e-4cc4-9a42-c24936fe9134/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited to 6 players per game, so sign up early!\n",
     "slug": "diversions-apr-08-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-04-01T16:39:59.000Z"
   },
   {
     "meta": {
@@ -235,7 +280,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** April 2, 2026\n- **Time:** 5:30 PM - 8:00 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n\n## Available Scenarios\n\n1. **Wayfinder Origins** (Pathfinder Quest, Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/495f7c2d-3871-47db-9262-1e2ff5c76551/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!\n",
     "slug": "tempest-apr-02-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-03-30T14:03:21.000Z"
   },
   {
     "meta": {
@@ -247,7 +293,8 @@
     },
     "content": "\n# Pathfinder Society at Replay Games\n\nJoin us for Pathfinder Society games at Replay Games in Cedar Rapids!\n\n## Details\n\n- **Date:** March 31, 2026\n- **Time:** 5:30 PM - 9:00 PM Central Time\n- **Location:** Replay Games\n- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402\n\n## Available Scenarios\n\n1. **Winter Queen's Dollhouse** (Pathfinder Quest, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/b4cfc2ec-88e5-4d1c-949c-aa21e24f1693/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 5 players per game, so sign up early!\n",
     "slug": "replay-mar-31-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-03-26T04:09:21.000Z"
   },
   {
     "meta": {
@@ -259,7 +306,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** March 29, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **Inheritor's Rite** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/d4a11654-66d9-471e-9e18-8a51ce52522c/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!\n\n",
     "slug": "gcg-mar-29-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-03-03T16:43:17.000Z"
   },
   {
     "meta": {
@@ -271,7 +319,8 @@
     },
     "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** March 25, 2026\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Magic in the Mist** (Starfinder Scenario, Levels 1-2) - **6:00 PM - 9:00 PM** - [Sign up here](https://www.rpgchronicles.net/session/8e485fa7-5a31-401b-a319-7157e22306b4/pregame)\n2. **Sewer Dragon Crisis** (Pathfinder Scenario, Levels 1-4) - **5:30 PM - 9:30 PM** - [Sign up here](https://www.rpgchronicles.net/session/a41b8e12-d083-45f5-8801-2ae4f01b92b7/pregame)\n3. **Once in Whispers** (Pathfinder Scenario, Levels 5-8) - **5:30 PM - 9:30 PM** - [Sign up here](https://www.rpgchronicles.net/session/c8bdd5c0-6cdc-43ca-ba30-3bafd2681720/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited to 6 players per game, so sign up early!\n",
     "slug": "diversions-mar-25-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-03-11T21:55:44.000Z"
   },
   {
     "meta": {
@@ -283,7 +332,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** March 19, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **Tanuki Trouble** (Quest, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/dee25749-f0c8-47d8-8215-d0d61a724473/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!\n",
     "slug": "tempest-mar-19-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-03-08T23:41:33.000Z"
   },
   {
     "meta": {
@@ -295,7 +345,8 @@
     },
     "content": "\n# Pathfinder Society at Replay Games\n\nJoin us for Pathfinder Society games at Replay Games in Cedar Rapids!\n\n## Details\n\n- **Date:** March 17, 2026\n- **Time:** 5:30 PM - 9:00 PM Central Time\n- **Location:** Replay Games\n- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402\n\n## Available Scenarios\n\n1. **The Mosquito Witch** (Pathfinder Scenario, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/b5083e6e-4dfc-4899-9123-57bbb6ca02c6/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 5 players per game, so sign up early!\n",
     "slug": "replay-mar-17-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-03-03T17:24:19.000Z"
   },
   {
     "meta": {
@@ -307,7 +358,8 @@
     },
     "content": "\n# Gamicon Bromine - Day 3\n\nJoin us for Pathfinder Society and Starfinder Society games at Gamicon Bromine!\n\n## Details\n\n- **Date:** March 8, 2026\n- **Time:** All Day Event\n- **Location:** Hyatt Regency Coralville Hotel & Conference Center\n- **Address:** 300 E 9th St, Coralville, IA 52241, USA\n\n**Important:** You must have a paid Gamicon badge to play. Badges are available at [Gamicon.org](https://gamicon.org) or at the venue the day of the event.\n\n## Available Scenarios\n\n### 9:00 AM Session\n\n1. **Upon Wheels and Rime** (Pathfinder) - GM: Bret I - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/79)\n2. **Godsrain in a Godless Land** (Pathfinder, Levels 5-8) - GM: Sam H - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/356)\n\n### 10:00 AM Session\n\n2. **Rites of Rekindling** (Starfinder) - GM: Hilary MM - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/74)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!\n",
     "slug": "gamicon-bromine-mar-08-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-02-21T13:21:03.000Z"
   },
   {
     "meta": {
@@ -319,7 +371,8 @@
     },
     "content": "\n# Gamicon Bromine - Day 2\n\nJoin us for Pathfinder Society and Starfinder Society games at Gamicon Bromine!\n\n## Details\n\n- **Date:** March 7, 2026\n- **Time:** All Day Event\n- **Location:** Hyatt Regency Coralville Hotel & Conference Center\n- **Address:** 300 E 9th St, Coralville, IA 52241, USA\n\n**Important:** You must have a paid Gamicon badge to play. Badges are available at [Gamicon.org](https://gamicon.org) or at the venue the day of the event.\n\n## Available Scenarios\n\n### 9:00 AM Sessions\n\n1. **Heidmarch Heist** (Pathfinder) - GM: Hilary MM - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/78)\n2. **Friends in Need** (Pathfinder) - GM: Marty H - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/85)\n\n### 10:00 AM Session\n\n3. **Take the Bait** (Starfinder) - GM: Bret I - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/76)\n\n### 1:00 PM Session\n\n4. **Swordlord's Challenge** (Pathfinder) - GM: Steve S - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/83)\n\n### 4:00 PM Sessions\n\n5. **Disaster at Dreamlink Labs** (Starfinder) - GM: Scott L - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/73)\n6. **The Chitterwood Walks, Part 1: Scrambling the Tribes** (Pathfinder) - GM: Sam H - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/81)\n\n### 5:00 PM Session\n\n7. **The Dragon's Plea** (Pathfinder) - GM: Josh G - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/87)\n\n### 8:00 PM Sessions\n\n8. **Foul Humors** (Starfinder) - GM: Scott L - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/77)\n9. **The Chitterwood Walks, Part 2: The Battle of Logas** (Pathfinder) - GM: Marty H - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/82)\n\n### 9:00 PM Session\n\n10. **Within the Glacier** (Pathfinder) - GM: Josh G - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/88)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!\n",
     "slug": "gamicon-bromine-mar-07-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-02-12T14:39:17.000Z"
   },
   {
     "meta": {
@@ -331,7 +384,8 @@
     },
     "content": "\n# Gamicon Bromine - Day 1\n\nJoin us for Pathfinder Society and Starfinder Society games at Gamicon Bromine!\n\n## Details\n\n- **Date:** March 6, 2026\n- **Time:** All Day Event\n- **Location:** Hyatt Regency Coralville Hotel & Conference Center\n- **Address:** 300 E 9th St, Coralville, IA 52241, USA\n\n**Important:** You must have a paid Gamicon badge to play. Badges are available at [Gamicon.org](https://gamicon.org) or at the venue the day of the event.\n\n## Available Scenarios\n\n### 1:00 PM Sessions\n\n1. **Friends of the Forest** (Starfinder) - GM: Bret I - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/75)\n2. **Shipyard Sabotage** (Pathfinder) - GM: Hilary MM - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/80)\n3. **Second Confirmation** (Pathfinder) - GM: Josh E - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/339)\n\n### 6:00 PM Sessions\n\n4. **Nova Rush** (Starfinder) - GM: Scott L - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/91)\n5. **Tanuki Trouble** (Pathfinder) - GM: Josh G - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/86)\n6. **Mischief in the Maze** (Pathfinder) - GM: Lindsay E - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/344)\n\n### 9:00 PM Session\n\n6. **The Winter Queen's Dollhouse** (Pathfinder) - GM: Steve S - [Sign up here](https://tabletop.events/conventions/gamicon-bromine/schedule/84)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!\n",
     "slug": "gamicon-bromine-mar-06-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-02-16T02:34:56.000Z"
   },
   {
     "meta": {
@@ -343,7 +397,8 @@
     },
     "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** February 25, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. All that Glitters (Pathfinder Scenario, Levels 1-4) - CANCELLED\n2. **Island of the Vibrant Dead** (Pathfinder Scenario, Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/3e639b62-632b-4cf2-a490-d25bf1803c95/pregame)\n3. **Abduction** (Starfinder Scenario, Levels 1-2) - [Sign up here](https://www.rpgchronicles.net/session/402f55cd-3aa3-4495-959a-08dd58903238/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited to 6 players per game, so sign up early!\n",
     "slug": "diversions-feb-25-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-02-24T23:22:31.000Z"
   },
   {
     "meta": {
@@ -355,7 +410,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** February 19, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **Port Peril Pub Crawl** (Quest, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/49171406-61b6-4bb1-8408-07979186188b/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!\n",
     "slug": "tempest-feb-19-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-01-31T15:49:49.000Z"
   },
   {
     "meta": {
@@ -367,7 +423,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** February 15, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **The Devil-Wrought Disappearance** (Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/077e0769-1e96-4b68-8e18-c78cc37ebc7e/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!\n",
     "slug": "gcg-feb-15-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-01-18T05:06:26.000Z"
   },
   {
     "meta": {
@@ -379,7 +436,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** February 11, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **The Fanciful March of Urawl** (Pathfinder Scenario, Levels 3-6) - Starting at 5:30 PM - [Sign up here](https://www.rpgchronicles.net/session/e1fa3869-96c4-4a17-946f-19e1c786cd76/pregame)\n2. **Unforgiving Fire** (Pathfinder Quest, Levels 1-4) - Starting at 5:30 PM - [Sign up here](https://www.rpgchronicles.net/session/38f140a2-3705-4eca-9c54-2ae962f67f9f/pregame)\n3. **Port Peril Pub Crawl** (Pathfinder Quest, Levels 1-4) - Starting at 7:00 PM - [Sign up here](https://www.rpgchronicles.net/session/ae28440b-adc2-4fac-b54a-21c97c87ae32/pregame)\n\n## Special Note\n\nThe two quests (Unforgiving Fire and Port Peril Pub Crawl) are each 90 minutes long and worth 1 XP each. Players can sign up for both quests or just one!\n\n## Registration\n\nPlease register in advance using the links above. Space is limited to 6 players per game, so sign up early!\n",
     "slug": "diversions-feb-11-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-02-03T13:46:22.000Z"
   },
   {
     "meta": {
@@ -391,7 +449,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** February 5, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **Lacking Respect** (Quest, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/b0c0aab7-8105-41bf-b148-67c508a02098/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!\n",
     "slug": "tempest-feb-05-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-01-19T04:01:30.000Z"
   },
   {
     "meta": {
@@ -403,7 +462,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** February 1, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **Devil at the Crossroads** (Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/dd0da737-18f7-46c9-bb68-927fd52a9c45/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!\n",
     "slug": "gcg-feb-01-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-01-18T05:06:26.000Z"
   },
   {
     "meta": {
@@ -415,7 +475,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** January 29, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **Escort a Mirage** (Quest, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/50b08817-de21-4451-a3e0-60f759a91f29/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "tempest-jan-29-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-01-16T16:07:09.000Z"
   },
   {
     "meta": {
@@ -427,7 +488,8 @@
     },
     "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** January 28, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Upon Wheels and Rime** (Pathfinder, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/34656298-7f8a-470b-86e5-b6a846c0a16e/pregame)\n2. **Seize and Destory** (Starfinder, Levels 1-2) - [Sign up here](https://www.rpgchronicles.net/session/7d255ee4-3085-4800-9558-78715f61181e/pregame)\n3. **The Blackwood Lost** (Pathfinder, Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/39ea1063-0d65-4453-b067-2fd47ac7ffba/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited to 6 players per game, so sign up early!",
     "slug": "diversions-jan-28-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-01-07T14:13:05.000Z"
   },
   {
     "meta": {
@@ -439,7 +501,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** January 18, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **The East Hill Haunting** - [Sign up here](https://www.rpgchronicles.net/session/35595f4c-00bb-40c7-8e2d-fffe7140acf7/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!",
     "slug": "gcg-jan-18-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-12-13T15:08:58.000Z"
   },
   {
     "meta": {
@@ -451,7 +514,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** January 15, 2026\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n\n## Available Scenarios\n\n1. **Within the Glacier** - [Sign up here](https://www.rpgchronicles.net/session/1f272ada-19a3-4ac9-9359-b2496bf2c04a/pregame)\n\n## Waitlist & Overflow Tables\n\nIf the main table fills up, we have additional seating available:\n\n2. **Within the Glacier** (Waitlist/Overflow Table) - [Sign up here](https://www.rpgchronicles.net/session/f43afc98-9b3c-4134-a43f-820057a217ef/pregame)\n\n*This table will only run if we have enough players to fill both the main table and overflow seating. Please sign up for the waitlist if the main table is full!*\n\n## Registration\n\nPlease register in advance using the links above. If the main table is full, please sign up for the waitlist table. We'll run the overflow table if we have sufficient players for both tables!",
     "slug": "tempest-jan-15-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2026-01-09T15:19:37.000Z"
   },
   {
     "meta": {
@@ -463,7 +527,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** January 14, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Lost in Flames** - [Sign up here](https://www.rpgchronicles.net/session/be080f90-5b24-428d-8fa8-aaee9a479914/pregame)\n2. **The Haunted Corridor** - [Sign up here](https://www.rpgchronicles.net/session/3160f64d-87c1-4810-91cd-ebdb15abeeb9/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited to 6 players per game, so sign up early!",
     "slug": "diversions-jan-14-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-12-30T14:49:04.000Z"
   },
   {
     "meta": {
@@ -475,7 +540,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** January 4, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **Intro: Year of Shattered Sanctuaries** - [Sign up here](https://www.rpgchronicles.net/session/b36977ba-f2ec-477b-9559-984874a9cf07/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!",
     "slug": "gcg-jan-04-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-12-27T15:59:12.000Z"
   },
   {
     "meta": {
@@ -487,7 +553,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** January 1, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Game Master:** Eli Farmer\n\n## Available Scenarios\n\n1. **Silver Bark, Golden Blades** - [Sign up here](https://www.rpgchronicles.net/session/6ab4e6f4-555b-415f-b537-dd531aac65e0/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!",
     "slug": "tempest-jan-01-2026",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-12-14T14:15:40.000Z"
   },
   {
     "meta": {
@@ -499,7 +566,8 @@
     },
     "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** December 24, 2025\n- **Time:** 4:30 PM - 7:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n- **Special Note:** Games start at an earlier time than normal (4:30 PM) and will last only 2-3 hours.\n\n## Available Scenarios\n\n### Starfinder Society\n1. **Seize and Destroy** (Levels 1-2) - [Sign up here](https://www.rpgchronicles.net/session/0e6916da-cde8-4760-b382-4ff36cf21e68/pregame)\n\n### Pathfinder Society\n1. **Dragon's Plea** (Quest, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/5e3150d6-3117-432b-9d3b-ddf496be5554/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!\n",
     "slug": "diversions-dec-24-2025",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-12-05T13:19:10.000Z"
   },
   {
     "meta": {
@@ -511,7 +579,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** December 18, 2025\n- **Time:** 5:30 PM - 7:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **The Elsewhere Feast** (Quest) - [Sign up here](https://www.rpgchronicles.net/session/cee04d36-433b-4d5e-8693-8c35df46d96b/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "tempest-dragon-evoking-day",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -523,7 +592,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** December 10, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Catastrophe's Spark** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/e17e8663-91be-4f93-9275-a8240797476c/pregame)\n2. **Brastlewark at War Part 1: The Gnome Defection** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/70617ede-7a42-4982-b0cc-b03e8b02500a/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited to 6 players per game, so sign up early!\n",
     "slug": "diversions-dec-10-2025",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-12-05T13:19:10.000Z"
   },
   {
     "meta": {
@@ -535,7 +605,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** December 7, 2025\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n- **Players:** 4 players\n- **Special Note:** This one-shot uses pregenerated characters. XP and Treasure can be applied to any Pathfinder Society character.\n\n## Available Scenarios\n\n1. **Dinner at Lionlodge** (One-Shot) - [Sign up here](https://www.rpgchronicles.net/session/283c0326-6f55-43b4-a1a6-694d47b41a6b/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 4 players, so sign up early!",
     "slug": "gcg-dinner-lionlodge",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -547,7 +618,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** December 4, 2025\n- **Time:** 5:30 PM - 7:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **The Greengold Dilemma** (Quest) - [Sign up here](https://www.rpgchronicles.net/session/5736cf43-1cd9-4a6e-b5bf-20c9f61beaf4/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "tempest-greengold-dilemma",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -559,7 +631,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** November 26, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Necessary Introductions** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/b56f8691-8983-4b55-8065-cb1bf6f7a593/pregame)\n2. **Sulfuric Negotiations** (Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/d0c86bf3-d8b8-47ee-bdf4-03a33e241606/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited to 6 players per game, so sign up early!",
     "slug": "diversions-nov-26-2025",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -571,7 +644,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** November 23, 2025\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **Second Confirmation** - [Sign up here](https://www.rpgchronicles.net/session/13cdf4e6-24f4-4e27-946a-1d6a0ccb3b20/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "tempest-second-confirmation-nov",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-21T15:28:29.000Z"
   },
   {
     "meta": {
@@ -583,7 +657,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** November 20, 2025\n- **Time:** 5:30 PM - 7:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **The Sandstone Secret** (Quest) - [Sign up here](https://www.rpgchronicles.net/session/9f171bb2-db9d-46f8-9c10-043157a3f517/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "tempest-sandstone-secret",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -595,7 +670,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** November 12, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Citadel of Corruption** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/574e7556-6d40-469a-8e35-6f7377603788/pregame)\n2. **Symposium on a Fallen God** (Levels 3-6) - [Sign up here](https://www.rpgchronicles.net/session/a437ca12-e16e-4074-8a2d-69610773e865/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited to 6 players per game, so sign up early!",
     "slug": "diversions-nov-12-2025",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -607,7 +683,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** November 6, 2025\n- **Time:** 5:30 PM - 7:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **Student Exchange** (Quest) - [Sign up here](https://www.rpgchronicles.net/session/ecb255d5-a0f5-4584-ac8d-e73d374b69cb/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "tempest-student-exchange",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -619,7 +696,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** November 2, 2025\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n- **Players:** 4 players\n- **Special Note:** This module uses pregenerated characters\n\n## Available Scenarios\n\n1. **Mark of the Mantis** (Module) - [Sign up here](https://www.rpgchronicles.net/session/2f44004f-f629-427e-a8c4-c58f4ed009d0/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 4 players, so sign up early!",
     "slug": "gcg-mark-of-mantis",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -631,7 +709,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** October 30, 2025\n- **Time:** 5:30 PM - 7:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **The Swordlord's Challenge** - [Sign up here](https://www.rpgchronicles.net/session/00cd2e81-8e12-4b5f-a54c-f35ace35cfc5/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "tempest-swordlords-challenge",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -643,7 +722,8 @@
     },
     "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** October 22, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n### Starfinder Society\n1. **Invasion's Edge** (Levels 1-2) - [Sign up here](https://www.rpgchronicles.net/session/83ebcbe8-2a3d-44b8-b79a-64c9bdaa15d6/pregame)\n\n### Pathfinder Society\n1. **Intro to Unfettered Exploration** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/28f5a541-caa1-4b2b-a48a-0ed8c9d3ce6a/pregame)\n2. **The Blooming Catastrophe** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/7772298d-53b6-478f-a948-ddef572fd43a/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!",
     "slug": "diversions-oct-22-2025",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -655,7 +735,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** October 19, 2025\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **Fury's Toll** - [Sign up here](https://www.rpgchronicles.net/session/c0653e80-7642-4bcb-ab93-b6b8e6563d72/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "gcg-furys-toll-oct",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -667,7 +748,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** October 2, 2025\n- **Time:** 5:30 PM - 7:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n\n## Available Scenarios\n\n1. **The Winter Queen's Dollhouse** - [Sign up here](https://www.rpgchronicles.net/session/22928d9b-3beb-4b6c-ad50-e7a60c8142cc/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "tempest-winter-queen-dollhouse",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -679,7 +761,8 @@
     },
     "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** September 24, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n### Starfinder Society\n1. **Dreamlink Labs** (Levels 1-2) - [Sign up here](https://www.rpgchronicles.net/session/95a103df-13cc-4cee-8a07-8d7dea9130c7/pregame)\n\n### Pathfinder Society\n1. **Arclord's Abode** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/bd1565cf-86cf-446f-ba4a-8d5a6da32c2e/pregame)\n2. **United in Purpose** (Levels 1-2) - [Sign up here](https://www.rpgchronicles.net/session/3b79f283-8380-4709-b0c6-fa74506ea0ef/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!",
     "slug": "diversions-sep-24-2025",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -691,7 +774,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** September 21, 2025\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n- **Players:** 6 players\n\n## Available Scenarios\n\n1. **Fury's Toll** - [Sign up here](https://www.rpgchronicles.net/session/7244b682-41d9-4e50-8dcc-cc8e9744e3e1/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "gcg-furys-toll",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -703,7 +787,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** September 18, 2025\n- **Time:** 5:30 PM - 7:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **Infernal Infiltration** - [Sign up here](https://www.rpgchronicles.net/session/c93bb5bf-97cb-4072-a922-80c018db3cf9/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "tempest-infernal-infiltration",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -715,7 +800,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** September 10, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Shipyard Sabotage** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/59aa83e4-ae3a-4177-b1f5-d208c3ce05ce/pregame)\n2. **Return to the Grave** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/64171021-1b29-4b7d-afc1-9292d2fe14c0/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!",
     "slug": "diversions-sep-10-2025",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -727,7 +813,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** September 7, 2025\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n- **Players:** 6 players\n- **Level Range:** 1-4\n\n## Available Scenarios\n\n1. **Sewer Dragon Crisis** - [Sign up here](https://www.rpgchronicles.net/session/010e5942-8722-48f0-b380-e839fecdce13/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "gcg-sewer-dragon-crisis",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -739,7 +826,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** September 4, 2025\n- **Time:** 5:30 PM - 7:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n- **Level Range:** 1-2\n\n## Available Scenarios\n\n1. **The Dacilane Academy's Show Must Go On** - [Sign up here](https://www.rpgchronicles.net/session/3028ffc6-0f67-45e7-ba77-a70e3c741a29/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "tempest-dacilane-academy",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -751,7 +839,8 @@
     },
     "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** August 27, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n### Pathfinder Society\n1. **The Arclord Who Never Was** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/23a3535e-127b-4eef-8b3e-b6b1ceb3ea77/pregame)\n2. **Enough is Enough** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/0f44070c-3ae2-44d0-b666-8a6ffc52e38c/pregame)\n\n### Starfinder Society\n1. **Mystery of the Frozen Moon** (Levels 1-2, 5:30 PM - 8:30 PM) - [Sign up here](https://www.rpgchronicles.net/session/eb62c1ba-2514-4981-9c95-b3250b4ac763/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!",
     "slug": "diversions-aug-27-2025",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -763,7 +852,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** August 21, 2025\n- **Time:** 5:30 PM - 7:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n\n## Available Scenarios\n\n1. **Friends in Need** - [Sign up here](https://www.rpgchronicles.net/session/ad20d81b-0f4d-489f-b32b-0fe903c61ce7/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!",
     "slug": "tempest-friends-need",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -775,7 +865,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** August 13, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Equal Exchanges - Necessary Introductions** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/07a089df-0586-45f3-b32d-58424e83932b/pregame)\n2. **Escaping the Grave** (Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/c8527f0c-c2dd-415f-adb4-7859171f2930/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!",
     "slug": "diversions-aug-13-2025",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -787,7 +878,8 @@
     },
     "content": "\n# Pathfinder Society at Tempest Games\n\nJoin us for Pathfinder Society games at Tempest Games in Cedar Rapids!\n\n## Details\n\n- **Date:** August 7, 2025\n- **Time:** 5:30 PM - 7:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n\n## Available Scenarios\n\n1. **In the Footsteps of Horror** - [Sign up here](https://www.rpgchronicles.net/session/d219533f-7c5f-4c3b-a1e2-d0cc5a4ba738/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!",
     "slug": "tempest-footsteps-horror",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -799,7 +891,8 @@
     },
     "content": "\n# Starfinder Society at Diversions - Battle for Nova Rush\n\nJoin us for Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** July 23, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Battle for Nova Rush** - [Sign up here](https://www.rpgchronicles.net/session/3793181b-71db-4409-91b3-b4a2cd28d469/pregame)\n\n## Special Note\n\n**This is the first Starfinder Second Edition game available for Organized Play credit!** Don't miss this opportunity to be among the first to play Starfinder 2E in an official Organized Play setting.\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!",
     "slug": "diversions-battle-nova-rush",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -811,7 +904,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions - Mischief in the Maze\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** July 23, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n- **Seats Available:** 6 players\n\n## Available Scenarios\n\n1. **Mischief in the Maze** - [Sign up here](https://www.rpgchronicles.net/session/049f7cb9-9dcf-498b-9cff-40813af5ec5d/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!",
     "slug": "diversions-mischief-maze",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -823,7 +917,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** July 13, 2025\n- **Time:** 12:00 noon - 5:00pm\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **Within the Prairies** - [Sign up here](https://www.rpgchronicles.net/session/5a519ffb-56a6-4eab-982f-9b8da8d232e2/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!",
     "slug": "gcg-13-july",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -836,7 +931,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions - Second Confirmation\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** July 9, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n- **Game Master:** Josh E\n\n## Available Scenarios\n\n1. **Second Confirmation** - [Sign up here](https://www.rpgchronicles.net/session/64258560-7190-4e5e-a167-1e6478b88482/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!",
     "slug": "diversions-second-confirmation",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -848,7 +944,8 @@
     },
     "content": "\n# Pathfinder Society at Diversions \n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** July 9, 2025\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Year of Immortal Influence: Intro** - [Sign up here](https://www.rpgchronicles.net/session/cabe4362-50e0-4447-b5fc-b7361b3d586c/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!",
     "slug": "diversions-symposium-fallen-god",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -860,7 +957,8 @@
     },
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** June 29, 2025\n- **Time:** 12:00 noon - 4:30pm\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **Negotiations for the Star Gun** - [Sign up here](https://www.rpgchronicles.net/session/1f7ab80c-4cdc-44c3-b13d-dcdb33d45d54/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!",
     "slug": "gcg-29-july",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -872,6 +970,7 @@
     },
     "content": "\n# Pathfinder Society at Diversions\n\nJoin us for Pathfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** June 25, 2025\n- **Time:** 5:30 PM - 9:30 PM\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n1. **Silver Bark, Golden Blades** - [Sign up here](https://www.rpgchronicles.net/session/ec927ed1-61f4-4441-af7f-de92051b4367/pregame)\n2. **All That Glitters** - [Sign up here](https://www.rpgchronicles.net/session/2d61cf38-9249-43b0-a514-5c849bd3d7e6/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!",
     "slug": "diversions-game-night",
-    "directory": "calendar"
+    "directory": "calendar",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   }
 ]


### PR DESCRIPTION
## Summary

- Renames the Jun 10 Starfinder scenario from "Seize and Destroy" to "Compliance Protocol"
- Adds Pathfinder scenario "Strings of Hell" (Levels 1-2, 5:30 PM, 6 players) to Jun 10
- Creates new Jun 24 Diversions event with two scenarios:
  - **Guardian's Covenant** — Pathfinder, Levels 3-6, 5:30 PM, 6 players
  - **Psychic Echoes** — Starfinder, Levels 1-2, 6:00 PM, 6 players

## Test plan

- [ ] Jun 10 event page shows "Compliance Protocol" (not "Seize and Destroy")
- [ ] Jun 10 event page shows "Strings of Hell" at 5:30 PM with correct signup link
- [ ] Jun 24 event page loads and shows both scenarios with correct signup links
- [ ] Calendar listing shows both Jun 10 and Jun 24 Diversions entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)