### PR TITLE
Add Jun 21 Pathfinder scenario Lions of Katapesh at GCG

### DIFF
--- a/public/feed.xml
+++ b/public/feed.xml
@@ -5,14 +5,21 @@
     <link>https://shiftingcorridors.com</link>
     <description>Upcoming Pathfinder and Starfinder Society events from the Shifting Corridors Lodge</description>
     <language>en-us</language>
-    <lastBuildDate>Fri, 05 Jun 2026 00:27:28 GMT</lastBuildDate>
+    <lastBuildDate>Sun, 07 Jun 2026 21:11:54 GMT</lastBuildDate>
     <atom:link href="https://shiftingcorridors.com/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Pathfinder &amp; Starfinder Society at Diversions - Jun 24</title>
       <link>https://shiftingcorridors.com/events/diversions-jun-24-2026</link>
       <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-jun-24-2026</guid>
-      <pubDate>Fri, 05 Jun 2026 00:27:28 GMT</pubDate>
+      <pubDate>Fri, 05 Jun 2026 00:29:32 GMT</pubDate>
       <description>Pathfinder &amp; Starfinder Society at Diversions - Jun 24 — Wednesday, June 24, 2026 — Diversions — 119 2nd St</description>
+    </item>
+    <item>
+      <title>Pathfinder Society at Geek City Games - Lions of Katapesh</title>
+      <link>https://shiftingcorridors.com/events/gcg-jun-21-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-jun-21-2026</guid>
+      <pubDate>Sun, 07 Jun 2026 21:11:53 GMT</pubDate>
+      <description>Pathfinder Society at Geek City Games - Lions of Katapesh — Sunday, June 21, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
     </item>
     <item>
       <title>Pathfinder Society at Tempest Games - Lost on the Spirit Road</title>
@@ -25,7 +32,7 @@
       <title>Pathfinder &amp; Starfinder Society at Diversions - Jun 10</title>
       <link>https://shiftingcorridors.com/events/diversions-jun-10-2026</link>
       <guid isPermaLink="true">https://shiftingcorridors.com/events/diversions-jun-10-2026</guid>
-      <pubDate>Thu, 04 Jun 2026 15:25:59 GMT</pubDate>
+      <pubDate>Fri, 05 Jun 2026 00:29:32 GMT</pubDate>
       <description>Pathfinder &amp; Starfinder Society at Diversions - Jun 10 — Wednesday, June 10, 2026 — Diversions — 119 2nd St</description>
     </item>
     <item>

--- a/src/content/calendar/gcg-jun-21-2026.md
+++ b/src/content/calendar/gcg-jun-21-2026.md
@@ -1,0 +1,26 @@
+---
+title: "Pathfinder Society at Geek City Games - Lions of Katapesh"
+date: 2026-06-21
+url: /events/gcg-jun-21-2026
+location: Geek City Games
+address: 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+---
+
+# Pathfinder Society at Geek City Games
+
+Join us for Pathfinder Society games at Geek City Games in North Liberty!
+
+## Details
+
+- **Date:** June 21, 2026
+- **Time:** 12:00 noon - 4:00 PM Central Time
+- **Location:** Geek City Games
+- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+
+## Available Scenarios
+
+1. **Lions of Katapesh** (Pathfinder Scenario, Levels 1-4, 6 players, Repeatable) - [Sign up here](https://www.rpgchronicles.net/session/4a18e40b-3fc1-4bc5-a52e-b35aeddaf719/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited, so sign up early!

--- a/src/data/calendar.json
+++ b/src/data/calendar.json
@@ -10,7 +10,20 @@
     "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** June 24, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n### Pathfinder Society\n1. **Guardian's Covenant** (Levels 3-6, starts 5:30 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/9d40025a-0eb4-4738-a499-929137cdfc6b/pregame)\n\n### Starfinder Society\n1. **Psychic Echoes** (Levels 1-2, starts 6:00 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/f3b2abc9-653b-439a-8a1c-7dc6d490c11e/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!\n",
     "slug": "diversions-jun-24-2026",
     "directory": "calendar",
-    "gitDate": "2026-06-05T00:27:28.624Z"
+    "gitDate": "2026-06-05T00:29:32.000Z"
+  },
+  {
+    "meta": {
+      "title": "Pathfinder Society at Geek City Games - Lions of Katapesh",
+      "date": "2026-06-21T00:00:00.000Z",
+      "url": "/events/gcg-jun-21-2026",
+      "location": "Geek City Games",
+      "address": "365 Beaver Kreek Center suite b, North Liberty, IA 52317"
+    },
+    "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** June 21, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **Lions of Katapesh** (Pathfinder Scenario, Levels 1-4, 6 players, Repeatable) - [Sign up here](https://www.rpgchronicles.net/session/4a18e40b-3fc1-4bc5-a52e-b35aeddaf719/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!",
+    "slug": "gcg-jun-21-2026",
+    "directory": "calendar",
+    "gitDate": "2026-06-07T21:11:53.984Z"
   },
   {
     "meta": {
@@ -36,7 +49,7 @@
     "content": "\n# Pathfinder & Starfinder Society at Diversions\n\nJoin us for Pathfinder and Starfinder Society games at Diversions in Coralville!\n\n## Details\n\n- **Date:** June 10, 2026\n- **Time:** 5:30 PM - 9:30 PM Central Time\n- **Location:** Diversions\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n\n## Available Scenarios\n\n### Pathfinder Society\n1. **Strings of Hell** (Levels 1-2, starts 5:30 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/83b43a5c-1257-4316-b94f-04a50ee8dcc6/pregame)\n\n### Starfinder Society\n1. **Compliance Protocol** (Levels 1-2, starts 6:00 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/1f67ef56-6b1c-49d0-8436-4806050a87db/pregame)\n\n## Registration\n\nPlease register in advance using the links above. Space is limited, so sign up early!\n",
     "slug": "diversions-jun-10-2026",
     "directory": "calendar",
-    "gitDate": "2026-06-04T15:25:59.000Z"
+    "gitDate": "2026-06-05T00:29:32.000Z"
   },
   {
     "meta": {


### PR DESCRIPTION
## Summary

- Adds calendar event for June 21, 2026 at Geek City Games
- Scenario: **Lions of Katapesh** (Pathfinder, Levels 1-4, 6 players, Repeatable)
- Includes updated `calendar.json` and `feed.xml` from content build

## Test plan

- [ ] Verify event appears on the calendar for June 21
- [ ] Confirm sign-up link resolves correctly
- [ ] Check RSS feed includes the new event

🤖 Generated with [Claude Code](https://claude.com/claude-code)