### PR TITLE
Add Grayce: Sabotage! two-session adventure at Tempest Games (Jul 2 & Jul 16)

### DIFF
--- a/public/feed.xml
+++ b/public/feed.xml
@@ -5,8 +5,22 @@
     <link>https://shiftingcorridors.com</link>
     <description>Upcoming Pathfinder and Starfinder Society events from the Shifting Corridors Lodge</description>
     <language>en-us</language>
-    <lastBuildDate>Sun, 07 Jun 2026 21:11:54 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 11 Jun 2026 20:38:11 GMT</lastBuildDate>
     <atom:link href="https://shiftingcorridors.com/feed.xml" rel="self" type="application/rss+xml"/>
+    <item>
+      <title>Grayce: Sabotage! Part 2</title>
+      <link>https://shiftingcorridors.com/events/tempest-jul-16-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-jul-16-2026</guid>
+      <pubDate>Thu, 11 Jun 2026 20:38:11 GMT</pubDate>
+      <description>Grayce: Sabotage! Part 2 — Thursday, July 16, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Grayce: Sabotage! Part 1</title>
+      <link>https://shiftingcorridors.com/events/tempest-jul-02-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-jul-02-2026</guid>
+      <pubDate>Thu, 11 Jun 2026 20:38:11 GMT</pubDate>
+      <description>Grayce: Sabotage! Part 1 — Thursday, July 2, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
     <item>
       <title>Pathfinder &amp; Starfinder Society at Diversions - Jun 24</title>
       <link>https://shiftingcorridors.com/events/diversions-jun-24-2026</link>
@@ -18,7 +32,7 @@
       <title>Pathfinder Society at Geek City Games - Lions of Katapesh</title>
       <link>https://shiftingcorridors.com/events/gcg-jun-21-2026</link>
       <guid isPermaLink="true">https://shiftingcorridors.com/events/gcg-jun-21-2026</guid>
-      <pubDate>Sun, 07 Jun 2026 21:11:53 GMT</pubDate>
+      <pubDate>Sun, 07 Jun 2026 21:13:44 GMT</pubDate>
       <description>Pathfinder Society at Geek City Games - Lions of Katapesh — Sunday, June 21, 2026 — Geek City Games — 365 Beaver Kreek Center suite b, North Liberty, IA 52317</description>
     </item>
     <item>

--- a/src/content/calendar/tempest-jul-02-2026.md
+++ b/src/content/calendar/tempest-jul-02-2026.md
@@ -1,0 +1,39 @@
+---
+title: "Grayce: Sabotage! Part 1"
+date: 2026-07-02
+url: /events/tempest-jul-02-2026
+location: Tempest Games
+address: 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+---
+
+# Grayce: Sabotage! Part 1
+
+Join us for a special Pathfinder adventure at Tempest Games in Cedar Rapids!
+
+## IMPORTANT: This Sign-Up Covers Two Sessions
+
+> **Signing up here registers you for BOTH sessions of this adventure — July 2 and July 16.**
+>
+> This adventure takes two full sessions to complete. Do not sign up unless you can attend both dates.
+
+## Details
+
+- **Dates:** July 2, 2026 (Part 1) and July 16, 2026 (Part 2)
+- **Time:** 5:30 PM Central Time
+- **Location:** Tempest Games
+- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+- **Players:** 6 players
+
+## Adventure
+
+**Sabotage!** (Pathfinder Adventure) — [Sign up here](https://www.rpgchronicles.net/session/8198d655-010a-4b5c-a188-f157ff3fa58a/pregame)
+
+## Character Requirements
+
+- **Level:** 2 only
+- **Starting Gear:** 30 gp worth of equipment
+- You must sign up using your **Pathfinder Society character** on RPGChronicles
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 6 players, so sign up early!

--- a/src/content/calendar/tempest-jul-16-2026.md
+++ b/src/content/calendar/tempest-jul-16-2026.md
@@ -1,0 +1,24 @@
+---
+title: "Grayce: Sabotage! Part 2"
+date: 2026-07-16
+url: /events/tempest-jul-16-2026
+location: Tempest Games
+address: 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+---
+
+# Grayce: Sabotage! Part 2
+
+The conclusion of Sabotage! — a special two-session Pathfinder adventure at Tempest Games in Cedar Rapids.
+
+## Details
+
+- **Date:** July 16, 2026 (Part 2 of 2)
+- **Time:** 5:30 PM Central Time
+- **Location:** Tempest Games
+- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+
+## Registration
+
+Sign-ups for this adventure are handled through the [July 2 event](/events/tempest-jul-02-2026). If you have not already registered, sign up there — your registration covers both sessions.
+
+If you are already signed up for Part 1, you are confirmed for this session as well.

--- a/src/data/calendar.json
+++ b/src/data/calendar.json
@@ -1,6 +1,32 @@
 [
   {
     "meta": {
+      "title": "Grayce: Sabotage! Part 2",
+      "date": "2026-07-16T00:00:00.000Z",
+      "url": "/events/tempest-jul-16-2026",
+      "location": "Tempest Games",
+      "address": "212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405"
+    },
+    "content": "\n# Grayce: Sabotage! Part 2\n\nThe conclusion of Sabotage! — a special two-session Pathfinder adventure at Tempest Games in Cedar Rapids.\n\n## Details\n\n- **Date:** July 16, 2026 (Part 2 of 2)\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n\n## Registration\n\nSign-ups for this adventure are handled through the [July 2 event](/events/tempest-jul-02-2026). If you have not already registered, sign up there — your registration covers both sessions.\n\nIf you are already signed up for Part 1, you are confirmed for this session as well.\n",
+    "slug": "tempest-jul-16-2026",
+    "directory": "calendar",
+    "gitDate": "2026-06-11T20:38:11.576Z"
+  },
+  {
+    "meta": {
+      "title": "Grayce: Sabotage! Part 1",
+      "date": "2026-07-02T00:00:00.000Z",
+      "url": "/events/tempest-jul-02-2026",
+      "location": "Tempest Games",
+      "address": "212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405"
+    },
+    "content": "\n# Grayce: Sabotage! Part 1\n\nJoin us for a special Pathfinder adventure at Tempest Games in Cedar Rapids!\n\n## IMPORTANT: This Sign-Up Covers Two Sessions\n\n> **Signing up here registers you for BOTH sessions of this adventure — July 2 and July 16.**\n>\n> This adventure takes two full sessions to complete. Do not sign up unless you can attend both dates.\n\n## Details\n\n- **Dates:** July 2, 2026 (Part 1) and July 16, 2026 (Part 2)\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n\n## Adventure\n\n**Sabotage!** (Pathfinder Adventure) — [Sign up here](https://www.rpgchronicles.net/session/8198d655-010a-4b5c-a188-f157ff3fa58a/pregame)\n\n## Character Requirements\n\n- **Level:** 2 only\n- **Starting Gear:** 30 gp worth of equipment\n- You must sign up using your **Pathfinder Society character** on RPGChronicles\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!\n",
+    "slug": "tempest-jul-02-2026",
+    "directory": "calendar",
+    "gitDate": "2026-06-11T20:38:11.572Z"
+  },
+  {
+    "meta": {
       "title": "Pathfinder & Starfinder Society at Diversions - Jun 24",
       "date": "2026-06-24T00:00:00.000Z",
       "url": "/events/diversions-jun-24-2026",
@@ -23,7 +49,7 @@
     "content": "\n# Pathfinder Society at Geek City Games\n\nJoin us for Pathfinder Society games at Geek City Games in North Liberty!\n\n## Details\n\n- **Date:** June 21, 2026\n- **Time:** 12:00 noon - 4:00 PM Central Time\n- **Location:** Geek City Games\n- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317\n\n## Available Scenarios\n\n1. **Lions of Katapesh** (Pathfinder Scenario, Levels 1-4, 6 players, Repeatable) - [Sign up here](https://www.rpgchronicles.net/session/4a18e40b-3fc1-4bc5-a52e-b35aeddaf719/pregame)\n\n## Registration\n\nPlease register in advance using the link above. Space is limited, so sign up early!",
     "slug": "gcg-jun-21-2026",
     "directory": "calendar",
-    "gitDate": "2026-06-07T21:11:53.984Z"
+    "gitDate": "2026-06-07T21:13:44.000Z"
   },
   {
     "meta": {

--- a/src/data/gamemasters.json
+++ b/src/data/gamemasters.json
@@ -12,7 +12,8 @@
     },
     "content": "\nEli is a dedicated Game Master who runs Pathfinder Society scenarios. With organized play number 6385146, Eli brings enthusiasm and expertise to create engaging adventures for players of all experience levels.",
     "slug": "eli-f",
-    "directory": "gamemasters"
+    "directory": "gamemasters",
+    "gitDate": "2025-12-27T15:59:12.000Z"
   },
   {
     "meta": {
@@ -26,7 +27,8 @@
     },
     "content": "\n# Josh E\n\n**Organized Play Number:** 8591\n\n**Systems:** Pathfinder, Starfinder\n\nJosh E is an experienced game master who runs both Pathfinder Society and Starfinder Society games. With organized play number 8591, Josh brings expertise in both fantasy and science fiction RPG systems to create engaging adventures for players of all experience levels.",
     "slug": "josh-e",
-    "directory": "gamemasters"
+    "directory": "gamemasters",
+    "gitDate": "2025-12-27T16:06:40.000Z"
   },
   {
     "meta": {
@@ -39,7 +41,8 @@
     },
     "content": "\nJosh is an experienced Game Master with a legacy of running games stretching back before Pathfinder existed. His sense of humor and desire to see the players laugh makes for a great experience.",
     "slug": "josh-g",
-    "directory": "gamemasters"
+    "directory": "gamemasters",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   },
   {
     "meta": {
@@ -54,7 +57,8 @@
     },
     "content": "\nMarty is the Corridor Venture-Lieutenant and a Game Master who runs scenarios for Pathfinder 2E and Starfinder 2E. He specializes in creating immersive roleplaying experiences and his collection of maps and lending of dice.",
     "slug": "marty-h",
-    "directory": "gamemasters"
+    "directory": "gamemasters",
+    "gitDate": "2025-12-27T16:20:16.000Z"
   },
   {
     "meta": {
@@ -69,7 +73,8 @@
     },
     "content": "\nSam is a dedicated Game Master who runs Pathfinder Society scenarios. With organized play number 5689143, Sam brings enthusiasm and expertise to create engaging adventures for players of all experience levels.",
     "slug": "sam-h",
-    "directory": "gamemasters"
+    "directory": "gamemasters",
+    "gitDate": "2025-12-27T15:59:12.000Z"
   },
   {
     "meta": {
@@ -83,7 +88,8 @@
     },
     "content": "\nScott is a dedicated Game Master who specializes in running Starfinder scenarios. With his organized play number 339339, Scott brings enthusiasm for science fiction adventures and helps players explore the vast universe of Starfinder Society games.",
     "slug": "scott-l",
-    "directory": "gamemasters"
+    "directory": "gamemasters",
+    "gitDate": "2026-02-10T17:39:42.000Z"
   },
   {
     "meta": {
@@ -99,6 +105,7 @@
     },
     "content": "\nSteve is a dedicated Game Master who runs Pathfinder Society scenarios. With organized play number 21564, Steve brings enthusiasm and expertise to create engaging adventures for players of all experience levels.",
     "slug": "steve-s",
-    "directory": "gamemasters"
+    "directory": "gamemasters",
+    "gitDate": "2026-05-31T13:07:16.000Z"
   }
 ]

--- a/src/data/news.json
+++ b/src/data/news.json
@@ -7,7 +7,8 @@
     },
     "content": "\n# Lodge Party - June 8th!\n\nYou've rolled a natural 20 on your social check — you're invited to the Shifting Corridors Lodge Party!\n\n## You're Invited\n\nOn **June 8th from 5:30 PM to 9:30 PM**, we're throwing a party for the people who make this lodge great: our players, GMs, Venture Officers, and Store Hosts. Families are welcome too — the more the merrier!\n\nDrop in when you can, leave when you need to. No pressure, no agenda, just good company.\n\n## What to Expect\n\n- Party games — both indoor and outdoor\n- Food served throughout the evening\n- Great company from across the lodge\n\n## Getting an Invite\n\nThe location is shared with the invite (we're keeping the address off the public internet). To get yours, reach out through any of these:\n\n- **Email:** [lodge@shiftingcorridors.com](mailto:lodge@shiftingcorridors.com)\n- **Discord:** Ask in the server\n- **In person:** Find Marty H or Sam H\n\nWe hope to see you there!\n",
     "slug": "lodge-party-jun-2026",
-    "directory": "news"
+    "directory": "news",
+    "gitDate": "2026-05-31T13:12:08.000Z"
   },
   {
     "meta": {
@@ -17,7 +18,8 @@
     },
     "content": "\n# No Show and Timeliness Policy\n\nWe're implementing a new policy across all our gaming locations to ensure fair access to tables for all players.\n\n## Policy Details\n\nEffective immediately, Diversions, Tempest Games, and Geek City Games are implementing a timeliness policy for organized play sessions:\n\n**If a player is more than 10 minutes late and there is a waitlist, their spot at the table will be given to the next person on the waitlist.**\n\n## Why This Policy?\n\nThis policy helps ensure that:\n- Players on waitlists have a fair opportunity to play\n- Game Masters can start sessions on time\n- All players who commit to attending are respectful of everyone's time\n\n## What This Means for You\n\n- **Arrive on time** - We recommend arriving 10-15 minutes early to get settled\n- **Communicate** - If you're running late, contact the Game Master or venue as soon as possible\n- **Sign up responsibly** - Only register for games you can commit to attending\n\n## Questions?\n\nIf you have questions about this policy, please reach out to your Game Master or join us on Discord at [https://discord.gg/X6gmXYVDJA](https://discord.gg/X6gmXYVDJA) in the #iowa-corridor channel. We appreciate your understanding and cooperation in making our organized play sessions enjoyable for everyone.\n\nThank you for being part of our gaming community!\n",
     "slug": "no-show-timeliness-policy",
-    "directory": "news"
+    "directory": "news",
+    "gitDate": "2025-12-05T13:19:10.000Z"
   },
   {
     "meta": {
@@ -27,7 +29,8 @@
     },
     "content": "\n# Shifting Corridors Lodge at Gamicon Bromine 2026\n\nWe're thrilled to announce that the Shifting Corridors Lodge will be hosting organized play at Gamicon Bromine, taking place March 6-8, 2026 in Coralville, Iowa!\n\n## Event Highlights\n\nThis is going to be our biggest convention presence yet. We'll be running an impressive 19 tables of organized play throughout the weekend, featuring both Pathfinder Society and Starfinder Society games. Whether you're a seasoned adventurer or new to organized play, there will be something for everyone.\n\n## Special Guest: Hilary Moon Murphy\n\nWe're honored to have special guest Hilary Moon Murphy joining us at the convention! Hilary is a talented author who has written scenarios for Paizo, and she'll be personally running three of her own scenarios during the event. This is a rare opportunity to experience her work firsthand with the author herself at the table.\n\n## Both Systems Represented\n\nPlayers will have the chance to dive into adventures across both game systems:\n- **Pathfinder Society** - Fantasy adventures in the world of Golarion\n- **Starfinder Society** - Science fiction exploration across the galaxy\n\n## Convention Information\n\nGamicon Bromine will be held in Coralville, Iowa. For complete convention details, schedules, and registration information, visit [Gamicon.org](https://gamicon.org).\n\nWe can't wait to see you there! Mark your calendars for March 6-8, 2026, and get ready for an unforgettable weekend of gaming.\n",
     "slug": "gamicon-bromine-2026",
-    "directory": "news"
+    "directory": "news",
+    "gitDate": "2025-11-25T14:48:11.000Z"
   },
   {
     "meta": {
@@ -37,6 +40,7 @@
     },
     "content": "\n# New Lodge Website Launched\n\nWe're excited to announce the launch of our new Shifting Corridors Lodge website!\n\nThis new site will help us better coordinate events and share information with our community.\n\n## Features\n\n- Event calendar with upcoming games\n- List of Game Masters\n- News updates\n- Contact information\n\nStay tuned for more updates and events!",
     "slug": "new-lodge-website",
-    "directory": "news"
+    "directory": "news",
+    "gitDate": "2025-11-19T16:48:03.000Z"
   }
 ]


### PR DESCRIPTION
## Summary

- Adds Jul 2, 2026 event for Part 1 of *Sabotage!* at Tempest Games with RPGChronicles signup link (6 players)
- Adds Jul 16, 2026 event for Part 2, directing players back to the Jul 2 signup
- Jul 2 event includes a prominent notice that signup covers both sessions, plus character requirements (level 2 only, 30 gp gear, PFS character on RPGChronicles)

## Test plan

- [ ] Both dates appear on the calendar
- [ ] Jul 2 event page shows the two-session warning and signup link
- [ ] Jul 16 event page links back to Jul 2 for registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)