### PR TITLE
Add Free RPG Day 2026 event (Jun 27)

### DIFF
--- a/public/feed.xml
+++ b/public/feed.xml
@@ -5,21 +5,28 @@
     <link>https://shiftingcorridors.com</link>
     <description>Upcoming Pathfinder and Starfinder Society events from the Shifting Corridors Lodge</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 11 Jun 2026 20:38:11 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 12 Jun 2026 14:01:31 GMT</lastBuildDate>
     <atom:link href="https://shiftingcorridors.com/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Grayce: Sabotage! Part 2</title>
       <link>https://shiftingcorridors.com/events/tempest-jul-16-2026</link>
       <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-jul-16-2026</guid>
-      <pubDate>Thu, 11 Jun 2026 20:38:11 GMT</pubDate>
+      <pubDate>Fri, 12 Jun 2026 13:53:52 GMT</pubDate>
       <description>Grayce: Sabotage! Part 2 — Thursday, July 16, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
     </item>
     <item>
       <title>Grayce: Sabotage! Part 1</title>
       <link>https://shiftingcorridors.com/events/tempest-jul-02-2026</link>
       <guid isPermaLink="true">https://shiftingcorridors.com/events/tempest-jul-02-2026</guid>
-      <pubDate>Thu, 11 Jun 2026 20:38:11 GMT</pubDate>
+      <pubDate>Fri, 12 Jun 2026 13:53:52 GMT</pubDate>
       <description>Grayce: Sabotage! Part 1 — Thursday, July 2, 2026 — Tempest Games — 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405</description>
+    </item>
+    <item>
+      <title>Free RPG Day 2026</title>
+      <link>https://shiftingcorridors.com/events/free-rpg-day-jun-27-2026</link>
+      <guid isPermaLink="true">https://shiftingcorridors.com/events/free-rpg-day-jun-27-2026</guid>
+      <pubDate>Fri, 12 Jun 2026 14:01:31 GMT</pubDate>
+      <description>Free RPG Day 2026 — Saturday, June 27, 2026 — Tempest Games &amp; Diversions — Cedar Rapids &amp; Coralville, IA</description>
     </item>
     <item>
       <title>Pathfinder &amp; Starfinder Society at Diversions - Jun 24</title>

--- a/src/content/calendar/free-rpg-day-jun-27-2026.md
+++ b/src/content/calendar/free-rpg-day-jun-27-2026.md
@@ -1,0 +1,34 @@
+---
+title: Free RPG Day 2026
+date: 2026-06-27
+url: /events/free-rpg-day-jun-27-2026
+location: Tempest Games & Diversions
+address: Cedar Rapids & Coralville, IA
+---
+
+# Free RPG Day 2026
+
+It's [Free RPG Day](https://freerpgday.com/)! Come celebrate tabletop RPGs with us at two locations across the Corridor. Walk-on games, free demos, and good company — no sign-up, no experience required, just show up and roll some dice!
+
+## Locations & Hours
+
+### Tempest Games — Cedar Rapids
+- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+- **Hours:** 11:00 AM – 5:00 PM
+
+### Diversions — Coralville
+- **Address:** 119 2nd St #300, Coralville, IA 52241
+- **Hours:** 11:00 AM – 11:00 PM
+
+## What's Happening
+
+- **Walk-on games all day** — just show up and join a table
+- **Pathfinder, Starfinder, and more** — including demos of non-Paizo systems
+- **Free demos** — a great chance to try something new
+- **Awesome raffles and discounts** — you might walk away with more than just XP
+
+Check [freerpgday.com](https://freerpgday.com/) for the full lineup of games and exclusive free giveaways available this year.
+
+## Everyone Is Welcome
+
+New to RPGs? Perfect — Free RPG Day is one of the best days to try one for the first time. Veteran adventurer? Come introduce someone new to the hobby. There's a table for everyone.

--- a/src/data/calendar.json
+++ b/src/data/calendar.json
@@ -10,7 +10,7 @@
     "content": "\n# Grayce: Sabotage! Part 2\n\nThe conclusion of Sabotage! — a special two-session Pathfinder adventure at Tempest Games in Cedar Rapids.\n\n## Details\n\n- **Date:** July 16, 2026 (Part 2 of 2)\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n\n## Registration\n\nSign-ups for this adventure are handled through the [July 2 event](/events/tempest-jul-02-2026). If you have not already registered, sign up there — your registration covers both sessions.\n\nIf you are already signed up for Part 1, you are confirmed for this session as well.\n",
     "slug": "tempest-jul-16-2026",
     "directory": "calendar",
-    "gitDate": "2026-06-11T20:38:11.576Z"
+    "gitDate": "2026-06-12T13:53:52.000Z"
   },
   {
     "meta": {
@@ -23,7 +23,20 @@
     "content": "\n# Grayce: Sabotage! Part 1\n\nJoin us for a special Pathfinder adventure at Tempest Games in Cedar Rapids!\n\n## IMPORTANT: This Sign-Up Covers Two Sessions\n\n> **Signing up here registers you for BOTH sessions of this adventure — July 2 and July 16.**\n>\n> This adventure takes two full sessions to complete. Do not sign up unless you can attend both dates.\n\n## Details\n\n- **Dates:** July 2, 2026 (Part 1) and July 16, 2026 (Part 2)\n- **Time:** 5:30 PM Central Time\n- **Location:** Tempest Games\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Players:** 6 players\n\n## Adventure\n\n**Sabotage!** (Pathfinder Adventure) — [Sign up here](https://www.rpgchronicles.net/session/8198d655-010a-4b5c-a188-f157ff3fa58a/pregame)\n\n## Character Requirements\n\n- **Level:** 2 only\n- **Starting Gear:** 30 gp worth of equipment\n- You must sign up using your **Pathfinder Society character** on RPGChronicles\n\n## Registration\n\nPlease register in advance using the link above. Space is limited to 6 players, so sign up early!\n",
     "slug": "tempest-jul-02-2026",
     "directory": "calendar",
-    "gitDate": "2026-06-11T20:38:11.572Z"
+    "gitDate": "2026-06-12T13:53:52.000Z"
+  },
+  {
+    "meta": {
+      "title": "Free RPG Day 2026",
+      "date": "2026-06-27T00:00:00.000Z",
+      "url": "/events/free-rpg-day-jun-27-2026",
+      "location": "Tempest Games & Diversions",
+      "address": "Cedar Rapids & Coralville, IA"
+    },
+    "content": "\n# Free RPG Day 2026\n\nIt's [Free RPG Day](https://freerpgday.com/)! Come celebrate tabletop RPGs with us at two locations across the Corridor. Walk-on games, free demos, and good company — no sign-up, no experience required, just show up and roll some dice!\n\n## Locations & Hours\n\n### Tempest Games — Cedar Rapids\n- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405\n- **Hours:** 11:00 AM – 5:00 PM\n\n### Diversions — Coralville\n- **Address:** 119 2nd St #300, Coralville, IA 52241\n- **Hours:** 11:00 AM – 11:00 PM\n\n## What's Happening\n\n- **Walk-on games all day** — just show up and join a table\n- **Pathfinder, Starfinder, and more** — including demos of non-Paizo systems\n- **Free demos** — a great chance to try something new\n- **Awesome raffles and discounts** — you might walk away with more than just XP\n\nCheck [freerpgday.com](https://freerpgday.com/) for the full lineup of games and exclusive free giveaways available this year.\n\n## Everyone Is Welcome\n\nNew to RPGs? Perfect — Free RPG Day is one of the best days to try one for the first time. Veteran adventurer? Come introduce someone new to the hobby. There's a table for everyone.\n",
+    "slug": "free-rpg-day-jun-27-2026",
+    "directory": "calendar",
+    "gitDate": "2026-06-12T14:01:31.720Z"
   },
   {
     "meta": {


### PR DESCRIPTION
## Summary

- Adds June 27, 2026 Free RPG Day event covering both Tempest Games (11am–5pm) and Diversions (11am–11pm)
- Walk-on format with Pathfinder, Starfinder, and non-Paizo demos
- Links to freerpgday.com for game lineup and giveaway details

## Test plan

- [ ] June 27 appears on the calendar as "Free RPG Day 2026"
- [ ] Event page shows both venue locations and hours
- [ ] Links to freerpgday.com are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)