### PR TITLE
Add Seven Secrets of Dacilane Academy to Jun 24 Diversions event

### DIFF
--- a/src/content/calendar/diversions-jun-24-2026.md
+++ b/src/content/calendar/diversions-jun-24-2026.md
@@ -21,6 +21,7 @@ Join us for Pathfinder and Starfinder Society games at Diversions in Coralville!
 
 ### Pathfinder Society
 1. **Guardian's Covenant** (Levels 3-6, starts 5:30 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/9d40025a-0eb4-4738-a499-929137cdfc6b/pregame)
+2. **The Seven Secrets of Dacilane Academy** (Levels 1-4, starts 5:30 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/27151df9-a833-407c-aa93-9b409d7afb3c/pregame)
 
 ### Starfinder Society
 1. **Psychic Echoes** (Levels 1-2, starts 6:00 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/f3b2abc9-653b-439a-8a1c-7dc6d490c11e/pregame)


### PR DESCRIPTION
## Summary
- Adds Pathfinder scenario "The Seven Secrets of Dacilane Academy" (Levels 1-4, 5:30 PM, 6 players) to the June 24 Diversions event
- Now a triple-header: two Pathfinder tables + one Starfinder table

## Test plan
- [ ] Confirm the new scenario appears correctly on the Jun 24 event page
- [ ] Verify signup link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)