### PR TITLE
Add Jun 23 Pathfinder scenario Tarnbreaker's Trail at Replay Games

### DIFF
--- a/src/content/calendar/replay-jun-23-2026.md
+++ b/src/content/calendar/replay-jun-23-2026.md
@@ -1,0 +1,27 @@
+---
+title: Pathfinder Society at Replay Games - Tarnbreaker's Trail
+date: 2026-06-23
+url: /events/replay-jun-23-2026
+location: Replay Games
+address: 617 Center Point Rd NE, Cedar Rapids, IA 52402
+---
+
+# Pathfinder Society at Replay Games
+
+Join us for Pathfinder Society games at Replay Games in Cedar Rapids!
+
+## Details
+
+- **Date:** June 23, 2026
+- **Time:** 5:30 PM Central Time
+- **Location:** Replay Games
+- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402
+- **Players:** 5 players
+
+## Available Scenarios
+
+1. **Tarnbreaker's Trail** (Pathfinder Scenario, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/0616e41c-a26a-40c8-932d-eb38e8123a0c/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 5 players, so sign up early!


### PR DESCRIPTION
## Summary

- Adds calendar event for June 23, 2026 at Replay Games (5:30 PM)
- Pathfinder Society scenario: Tarnbreaker's Trail (Levels 1-4)
- 5-player cap with RPG Chronicles signup link

## Test plan

- [ ] Verify event appears on calendar for June 23
- [ ] Confirm signup link routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)