### PR TITLE
Add Jul 7 Starfinder scenario Invasion's Edge at Replay Games

### DIFF
--- a/src/content/calendar/replay-jul-07-2026.md
+++ b/src/content/calendar/replay-jul-07-2026.md
@@ -1,0 +1,27 @@
+---
+title: Starfinder Society at Replay Games - Invasion's Edge
+date: 2026-07-07
+url: /events/replay-jul-07-2026
+location: Replay Games
+address: 617 Center Point Rd NE, Cedar Rapids, IA 52402
+---
+
+# Starfinder Society at Replay Games
+
+Join us for Starfinder Society games at Replay Games in Cedar Rapids!
+
+## Details
+
+- **Date:** July 7, 2026
+- **Time:** 5:30 PM Central Time
+- **Location:** Replay Games
+- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402
+- **Players:** 6 players
+
+## Available Scenarios
+
+1. **Invasion's Edge** (Starfinder Scenario, Levels 1-2) - [Sign up here](https://www.rpgchronicles.net/session/fa684e3b-75e0-4b26-a91e-4e8d1da020f9/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 6 players, so sign up early!


### PR DESCRIPTION
## Summary

- Adds July 7, 2026 Starfinder Society event at Replay Games
- Scenario: Invasion's Edge (Levels 1-2), 6 players, 5:30 PM

## Test plan

- [ ] Verify event appears on calendar
- [ ] Confirm signup link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)