### PR TITLE
Add Jul 8 Starfinder scenario Sloughscar Summit at Diversions

### DIFF
--- a/src/content/calendar/diversions-jul-08-2026.md
+++ b/src/content/calendar/diversions-jul-08-2026.md
@@ -1,0 +1,27 @@
+---
+title: Starfinder Society at Diversions - Jul 8
+date: 2026-07-08
+url: /events/diversions-jul-08-2026
+location: Diversions
+address: 119 2nd St #300, Coralville, IA 52241
+---
+
+# Starfinder Society at Diversions
+
+Join us for Starfinder Society games at Diversions in Coralville!
+
+## Details
+
+- **Date:** July 8, 2026
+- **Time:** 6:00 PM Central Time
+- **Location:** Diversions
+- **Address:** 119 2nd St #300, Coralville, IA 52241
+
+## Available Scenarios
+
+### Starfinder Society
+1. **Sloughscar Summit** (Levels 1-2, starts 6:00 PM, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/070f2a6e-fd8e-4f52-afb7-934f65b1877c/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 6 players, so sign up early!


### PR DESCRIPTION
## Summary

- Adds July 8, 2026 Starfinder Society event at Diversions
- Scenario: Sloughscar Summit (Levels 1-2), 6 players, 6:00 PM

## Test plan

- [ ] Verify event appears on calendar
- [ ] Confirm signup link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)