### PR TITLE
Add Jul 19 Pathfinder scenario No Time for Treason at GCG

### DIFF
--- a/src/content/calendar/gcg-jul-19-2026.md
+++ b/src/content/calendar/gcg-jul-19-2026.md
@@ -1,0 +1,26 @@
+---
+title: "Pathfinder Society at Geek City Games - No Time for Treason"
+date: 2026-07-19
+url: /events/gcg-jul-19-2026
+location: Geek City Games
+address: 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+---
+
+# Pathfinder Society at Geek City Games
+
+Join us for Pathfinder Society games at Geek City Games in North Liberty!
+
+## Details
+
+- **Date:** July 19, 2026
+- **Time:** 12:00 noon - 4:00 PM Central Time
+- **Location:** Geek City Games
+- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+
+## Available Scenarios
+
+1. **No Time for Treason** (Pathfinder Scenario, Levels 3-6, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/12dfc66b-f919-4585-8ff4-63a73db426fc/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited, so sign up early!


### PR DESCRIPTION
## Summary

- Adds July 19, 2026 Pathfinder Society event at Geek City Games
- Scenario: No Time for Treason (Levels 3-6), 6 players, 12:00 noon

## Test plan

- [ ] Verify event appears on calendar
- [ ] Confirm signup link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)