### PR TITLE
Add Jul 21 Pathfinder scenario Tarnbreaker's Trail at Replay Games

### DIFF
--- a/src/content/calendar/replay-jul-21-2026.md
+++ b/src/content/calendar/replay-jul-21-2026.md
@@ -1,0 +1,27 @@
+---
+title: Pathfinder Society at Replay Games - Tarnbreaker's Trail
+date: 2026-07-21
+url: /events/replay-jul-21-2026
+location: Replay Games
+address: 617 Center Point Rd NE, Cedar Rapids, IA 52402
+---
+
+# Pathfinder Society at Replay Games
+
+Join us for Pathfinder Society games at Replay Games in Cedar Rapids!
+
+## Details
+
+- **Date:** July 21, 2026
+- **Time:** 5:30 PM Central Time
+- **Location:** Replay Games
+- **Address:** 617 Center Point Rd NE, Cedar Rapids, IA 52402
+- **Players:** 5 players
+
+## Available Scenarios
+
+1. **Tarnbreaker's Trail** (Pathfinder Scenario, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/e6f1fe6a-3595-4310-bb94-9ef8ca7f57a2/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 5 players, so sign up early!


### PR DESCRIPTION
## Summary

- Adds July 21, 2026 Pathfinder Society event at Replay Games
- Scenario: Tarnbreaker's Trail (Levels 1-4), 5 players, 5:30 PM

## Test plan

- [ ] Verify event appears on calendar
- [ ] Confirm signup link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)