### PR TITLE
Add Aug 2 Pathfinder scenario Escape from Oppara at GCG

### DIFF
--- a/src/content/calendar/gcg-aug-02-2026.md
+++ b/src/content/calendar/gcg-aug-02-2026.md
@@ -1,0 +1,26 @@
+---
+title: "Pathfinder Society at Geek City Games - Escape from Oppara"
+date: 2026-08-02
+url: /events/gcg-aug-02-2026
+location: Geek City Games
+address: 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+---
+
+# Pathfinder Society at Geek City Games
+
+Join us for Pathfinder Society games at Geek City Games in North Liberty!
+
+## Details
+
+- **Date:** August 2, 2026
+- **Time:** 12:00 noon - 4:00 PM Central Time
+- **Location:** Geek City Games
+- **Address:** 365 Beaver Kreek Center suite b, North Liberty, IA 52317
+
+## Available Scenarios
+
+1. **Escape from Oppara** (Pathfinder Scenario, Levels 3-6, 6 players) - [Sign up here](https://www.rpgchronicles.net/session/af0a0080-860d-45df-981a-e52121fb88e9/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited, so sign up early!


### PR DESCRIPTION
## Summary

- Adds August 2, 2026 Pathfinder Society event at Geek City Games
- Scenario: Escape from Oppara (Levels 3-6), 6 players, 12:00 noon

## Test plan

- [ ] Verify event appears on calendar
- [ ] Confirm signup link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)