### PR TITLE
Add Zachary Fox to GM roster

### DIFF
--- a/src/content/gamemasters/zachary-f.md
+++ b/src/content/gamemasters/zachary-f.md
@@ -1,0 +1,10 @@
+---
+title: "Game Master: Zachary F."
+date: 2026-06-29
+firstName: Zachary
+lastInitial: F
+organizedPlayNumber: 39392
+games: ['Pathfinder', 'Starfinder']
+---
+
+Zachary is a Game Master who runs Pathfinder Society and Starfinder Society scenarios. With organized play number 39392, Zachary brings enthusiasm and expertise to create engaging adventures for players of all experience levels.


### PR DESCRIPTION
## Summary

- Adds Zachary Fox (Org Play #39392) to the GM roster
- Runs Pathfinder Society and Starfinder Society

## Test plan

- [ ] Verify Zachary appears on the GM roster page

🤖 Generated with [Claude Code](https://claude.com/claude-code)