### PR TITLE
Add Jul 16 Pathfinder scenario The Home of Empty Breath at Tempest

### DIFF
--- a/src/content/calendar/tempest-jul-16-2026.md
+++ b/src/content/calendar/tempest-jul-16-2026.md
@@ -1,0 +1,32 @@
+---
+title: "The Home of Empty Breath"
+date: 2026-07-16
+url: /events/tempest-jul-16-2026
+location: Tempest Games
+address: 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+---
+
+# The Home of Empty Breath
+
+Join us for a Pathfinder Society scenario at Tempest Games in Cedar Rapids!
+
+## Details
+
+- **Date:** July 16, 2026
+- **Time:** 5:30 PM Central Time
+- **Location:** Tempest Games
+- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+- **Players:** 6 players
+
+## Adventure
+
+**The Home of Empty Breath** (Pathfinder Society Scenario) — [Sign up here](https://www.rpgchronicles.net/session/1f4907ec-b7ca-4cb0-95ce-528c9a0d1778/pregame)
+
+## Character Requirements
+
+- **Levels:** 5–6
+- You must sign up using your **Pathfinder Society character** on RPGChronicles
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 6 players, so sign up early!

--- a/src/content/calendar/tempest-jul-16-2026.md
+++ b/src/content/calendar/tempest-jul-16-2026.md
@@ -1,14 +1,14 @@
 ---
-title: "The Home of Empty Breath"
+title: Pathfinder Society at Tempest Games - The Home of Empty Breath
 date: 2026-07-16
 url: /events/tempest-jul-16-2026
 location: Tempest Games
 address: 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
 ---
 
-# The Home of Empty Breath
+# Pathfinder Society at Tempest Games
 
-Join us for a Pathfinder Society scenario at Tempest Games in Cedar Rapids!
+Join us for Pathfinder Society games at Tempest Games in Cedar Rapids!
 
 ## Details
 
@@ -18,14 +18,9 @@ Join us for a Pathfinder Society scenario at Tempest Games in Cedar Rapids!
 - **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
 - **Players:** 6 players
 
-## Adventure
+## Available Scenarios
 
-**The Home of Empty Breath** (Pathfinder Society Scenario) — [Sign up here](https://www.rpgchronicles.net/session/1f4907ec-b7ca-4cb0-95ce-528c9a0d1778/pregame)
-
-## Character Requirements
-
-- **Levels:** 5–6
-- You must sign up using your **Pathfinder Society character** on RPGChronicles
+1. **The Home of Empty Breath** (Pathfinder Scenario, Levels 5-6) - [Sign up here](https://www.rpgchronicles.net/session/1f4907ec-b7ca-4cb0-95ce-528c9a0d1778/pregame)
 
 ## Registration
 

--- a/src/content/calendar/tempest-jul-30-2026.md
+++ b/src/content/calendar/tempest-jul-30-2026.md
@@ -1,0 +1,27 @@
+---
+title: Pathfinder Society at Tempest Games - Lost on the Spirit Road
+date: 2026-07-30
+url: /events/tempest-jul-30-2026
+location: Tempest Games
+address: 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+---
+
+# Pathfinder Society at Tempest Games
+
+Join us for Pathfinder Society games at Tempest Games in Cedar Rapids!
+
+## Details
+
+- **Date:** July 30, 2026
+- **Time:** 5:30 PM Central Time
+- **Location:** Tempest Games
+- **Address:** 212 Edgewood Road NW, Suite K, Cedar Rapids, IA 52405
+- **Players:** 6 players
+
+## Available Scenarios
+
+1. **Lost on the Spirit Road** (Pathfinder Scenario, Levels 1-4) - [Sign up here](https://www.rpgchronicles.net/session/0d94e467-0bce-4885-86bf-3054fc7c35c2/pregame)
+
+## Registration
+
+Please register in advance using the link above. Space is limited to 6 players, so sign up early!


### PR DESCRIPTION
## Summary

- Adds Jul 16 Pathfinder Society scenario **The Home of Empty Breath** at Tempest Games
- Levels 5–6, 6 players, 5:30 PM CT

🤖 Generated with [Claude Code](https://claude.com/claude-code)